### PR TITLE
Add ruby-2-4-1-qt5 image and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,19 @@
 
 Public Docker images for Artsy applications
 
+# Build Image
+Build specific image by going to that image folder and run:
+```shell
+docker build -t artsy/<image name> .
+```
+
 If you would like to rebuild images in order of their dependencies, run `./bin/build.sh`
+
+
+# Push to Docker hub
+If it's a new image, you need to first create repository on [Docker Hub](https://hub.docker.com).
+
+Once you created repository, build image and tag it properly and then push it to docker hub by:
+```shell
+docker push artsy/<the tag you just created>
+```

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,7 +4,7 @@ set -e
 
 DIR=`pwd`
 
-for IMAGE in alpine-glibc alpine-oraclejdk8 alpine-scala
+for IMAGE in alpine-glibc alpine-oraclejdk8 alpine-scala ruby-2-3-3-with-qt5 ruby-2-4-1-with-qt5
 do
   cd $DIR/$IMAGE
   docker build -t artsy/$IMAGE .

--- a/ruby-2-4-1-with-qt5/Dockerfile
+++ b/ruby-2-4-1-with-qt5/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.4.1
+ARG BUNDLE_GITHUB__COM
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x xvfb
+
+RUN gem update --system && \
+    gem install bundler

--- a/ruby-2-4-1-with-qt5/Dockerfile
+++ b/ruby-2-4-1-with-qt5/Dockerfile
@@ -1,9 +1,14 @@
 FROM ruby:2.4.1
 ARG BUNDLE_GITHUB__COM
 
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash
 # Install dependencies
 RUN apt-get update && \
     apt-get install -y qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x xvfb
 
+RUN apt-get install -y nodejs
+
 RUN gem update --system && \
     gem install bundler
+
+RUN npm -v


### PR DESCRIPTION
# Problem
Current `ruby-qt5` is based on `ruby 2.3.1` while we have some apps on `ruby 2.4.1`.

# Solution
Build image for `ruby 2.4.1` with `qt5`. 

Already pushed it here:
https://hub.docker.com/r/artsy/ruby-2-4-1-qt5/

We may want to also rename our other image to mention its based on ruby 2.3.1