### PR TITLE
Add image for testing Volt on CircleCI

### DIFF
--- a/volt-testing/Dockerfile
+++ b/volt-testing/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/ruby:2.4.1-node-browsers
+ARG BUNDLE_GITHUB__COM
+
+# Install dependencies
+RUN sudo apt-get update && \
+    sudo apt-get install -y qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x xvfb
+
+RUN gem update --system && \
+    gem install bundler


### PR DESCRIPTION
While going through the process of getting Volt on Circle CI 2.0, I made an image that includes qt.