### PR TITLE
Add Ruby image with node and chrome

### DIFF
--- a/ruby/2.5.1-node-chrome/Dockerfile
+++ b/ruby/2.5.1-node-chrome/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.5.1
+
+# Install NodeJS apt sources
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+# Add Chrome source
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+
+RUN apt-get update -qq
+RUN apt-get install -y nodejs libnss3 libgconf-2-4 google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Disable Chrome sandbox
+RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+
+RUN gem update --system
+RUN gem install bundler
+
+RUN npm install -g yarn


### PR DESCRIPTION
This PR adds a really basic Ruby image with node and chrome for either testing on Circle or deployment on our k8s cloud. I've chosen a folder structure where ruby is the folder and the tag includes the version and "extras" included. In the future, I see our other ruby images going here.

The motivation for this work was https://github.com/artsy/bearden/pull/347 where I was trying to upgrade to the latest Ruby. I was blocked because I was dependent on Circle and their upgrade schedule. In order to upgrade Ruby to 2.5.1, I had to wait until they updated their images. Making our own puts us back in control there.