### PR TITLE
elixir 1.6.6 base image

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,0 +1,29 @@
+FROM bitnami/minideb
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+  && apt-get install -y locales curl gnupg
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+  dpkg-reconfigure --frontend=noninteractive locales && \
+  update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8 
+
+RUN curl -O https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
+  && dpkg -i erlang-solutions_1.0_all.deb
+
+RUN apt-get update -qq \
+  && apt-get install -y esl-erlang elixir
+
+# for use on CircleCI to wait for a database container to be ready
+# postgres example: dockerize -wait tcp://localhost:5432 -timeout 1m
+#
+ENV DOCKERIZE_VERSION=v0.6.1
+RUN curl -OL https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN rm -rf /var/lib/apt/* /var/cache/apt/* \
+  && mix local.hex --force \
+  && mix local.rebar --force


### PR DESCRIPTION
I've already pushed this to https://hub.docker.com/r/artsy/elixir/.

Some recent libraries weren't compiling without bringing back in a full Erlang installation.