### PR TITLE
update graalvm to 1.0.0-rc8

### DIFF
--- a/graalvm/Dockerfile
+++ b/graalvm/Dockerfile
@@ -1,6 +1,6 @@
 FROM  debian:stretch
 
-ENV   GRAAL_VERSION=1.0.0-rc2
+ENV   GRAAL_VERSION=1.0.0-rc8
 ENV   GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
 
 RUN   apt-get update && \


### PR DESCRIPTION
I already pushed this to https://hub.docker.com/r/artsy/graalvm/.

cc @erikdstock @javamonn 