### PR TITLE
Add dockerizer, update scala version

### DIFF
--- a/graalvm/Dockerfile
+++ b/graalvm/Dockerfile
@@ -1,10 +1,14 @@
 FROM  debian:stretch
 
-ENV   GRAAL_VERSION=1.0.0-rc8
-ENV   GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
+ENV GRAAL_VERSION=1.0.0-rc8
+ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
+ENV DOCKERIZE_VERSION v0.6.1
+RUN apt-get update && \
+    apt-get install -y wget tar gzip
 
-RUN   apt-get update && \
-      apt-get install -y wget tar gzip
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN   cd /tmp && \
       wget -q $GRAAL_CE_URL -O graalvm-ce-linux-amd64.tar.gz && \

--- a/graalvm/Dockerfile
+++ b/graalvm/Dockerfile
@@ -2,7 +2,7 @@ FROM  debian:stretch
 
 ENV GRAAL_VERSION=1.0.0-rc8
 ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION=v0.6.1
 RUN apt-get update && \
     apt-get install -y wget tar gzip
 

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,15 +1,21 @@
 FROM openjdk:8
 
-ENV SCALA_VERSION=2.12.3 \
-    SBT_VERSION=0.13.15
+ENV SCALA_VERSION=2.12.7 \
+    SBT_VERSION=0.13.17 \
+    DOCKERIZE_VERSION=v0.6.1
 
-RUN apt-get update -qq && apt-get install -y curl postgresql-client awscli jq
-RUN cd "/tmp" && \
+RUN apt-get update -qq && apt-get install -y wget curl tar gzip postgresql-client awscli jq && \
+    cd "/tmp" && \
+    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     curl -q -L -O www.scala-lang.org/files/archive/scala-$SCALA_VERSION.deb && \
     dpkg -i scala-$SCALA_VERSION.deb && \
     curl -q -L -O https://bintray.com/artifact/download/sbt/debian/sbt-$SBT_VERSION.deb && \
     dpkg -i sbt-$SBT_VERSION.deb && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN scala -version && \
-    sbt about
+    sbt about && \
+    node -v

--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -16,6 +16,11 @@ RUN apt-get update -qq && apt-get install -y wget curl tar gzip postgresql-clien
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN scala -version && \
-    sbt about && \
-    node -v
+# Trigger compiler-interface compilation
+RUN  cd "/tmp" && \
+  mkdir -p project src/main/scala && \
+  echo "sbt.version = ${SBT_VERSION}" > project/build.properties && \
+  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
+  touch src/main/scala/scratch.scala && \
+  sbt compile && \
+  rm -rf *

--- a/scala/graalvm/Dockerfile
+++ b/scala/graalvm/Dockerfile
@@ -1,6 +1,6 @@
 FROM artsy/graalvm
 
-ENV SCALA_VERSION=2.12.4 \
+ENV SCALA_VERSION=2.12.7 \
     SBT_VERSION=0.13.17
 
 RUN apt-get update -qq && apt-get install -y curl postgresql-client awscli jq git
@@ -14,7 +14,7 @@ RUN cd "/tmp" && \
 
 RUN apt-get clean
 
-ENV PATH=/usr/local/sbt/bin:/usr/local/scala-2.12.4/bin:$PATH
+ENV PATH=/usr/local/sbt/bin:/usr/local/scala-$SCALA_VERSION/bin:$PATH
 
 RUN scala -version && \
     sbt about


### PR DESCRIPTION
I already pushed these to docker hub.

I tagged the new non-GraalVM image as `artsy/scala:2.12.7-node`.

cc @erikdstock @javamonn 