### PR TITLE
Add openjdk image with flyway already installed

### DIFF
--- a/java/openjdk-8-jre-flyway/Dockerfile
+++ b/java/openjdk-8-jre-flyway/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:8-jre-slim
+
+ENV LANG C.UTF-8
+
+ADD https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.1.2/flyway-commandline-4.1.2-linux-x64.tar.gz /tmp/flyway.tar.gz
+RUN mkdir -p /opt/flyway && \
+  tar xf /tmp/flyway.tar.gz -C /opt/flyway --strip-components=1 \
+  && chmod 755 /opt/flyway/flyway

--- a/java/openjdk-8-jre-flyway/README.md
+++ b/java/openjdk-8-jre-flyway/README.md
@@ -1,0 +1,10 @@
+# OpenJDK 8 JRE with Flyway Docker image
+
+This image is based on [openjdk:8-jre-slim](https://hub.docker.com/_/openjdk/),
+and contains a [Flyway](https://flywaydb.org/) binary for database migrations.
+
+## Usage Example
+
+```Dockerfile
+FROM artsy/openjdk:8-jre-flyway
+```


### PR DESCRIPTION
This adds [Flyway](https://flywaydb.org/) so that we don't have to install it every time we deploy Causality.

I already tagged and pushed this to Docker Hub:

https://cloud.docker.com/u/artsy/repository/docker/artsy/openjdk

