### PR TITLE
Add Ruby 2.6.1 node chrome

### DIFF
--- a/ruby/2.6.1-node-chrome/Dockerfile
+++ b/ruby/2.6.1-node-chrome/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.6.1
+
+# Install NodeJS apt sources
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+# Add Chrome source
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+
+RUN apt-get update -qq
+RUN apt-get install -y nodejs libnss3 libgconf-2-4 google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Disable Chrome sandbox
+RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+
+RUN gem update --system
+RUN gem install bundler
+
+RUN npm install -g yarn


### PR DESCRIPTION
I've been lax in my addition of new Ruby images, so this PR adds 2.6.1 while I wait for the official 2.6.2 to land. These PRs are weird - by the time I've opened this the new image is actually already pushed to DockerHub. 🤷‍♂️ 