### PR TITLE
add elasticsearch wrapper to delay shutdown

### DIFF
--- a/elasticsearch/5.6/Dockerfile
+++ b/elasticsearch/5.6/Dockerfile
@@ -1,3 +1,6 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.16
 COPY artsy-similarity-plugin-1.0 /usr/share/elasticsearch/plugins/artsy-similarity-plugin-1.0
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin list
+
+COPY es-wrapper.sh bin/es-wrapper.sh
+CMD ["/bin/bash", "bin/es-wrapper.sh"]

--- a/elasticsearch/5.6/es-wrapper.sh
+++ b/elasticsearch/5.6/es-wrapper.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+start() {
+    bin/es-docker &
+    pid="$!"
+    wait
+}
+
+stop() {
+    kill $pid
+    echo "Caught SIGTERM - sleeping 10 seconds before shutdown..."
+    sleep 10
+}
+
+trap stop SIGTERM
+start


### PR DESCRIPTION
Noticing that the cluster goes to a "red" state while rotating nodes, due to failures to sync cluster state.  This is caused by the pod's network interface being deleted before other nodes in the cluster can detect it as down.

This issue is detailed in https://discuss.elastic.co/t/timed-out-waiting-for-all-nodes-to-process-published-state-and-cluster-unavailability/138590 and https://github.com/elastic/helm-charts/issues/63

As a workaround, adopted a pattern from https://github.com/qoqodev/elasticsearch-hooks-docker to wait for 10 seconds after shutting down the Elasticsearch process before exiting, so other nodes have time to detect the terminating node, re-elect a new master and sync cluster state.