### PR TITLE
Scala 2.12.8 images based on Amazon Corretto

### DIFF
--- a/scala/scala-2.12/Dockerfile
+++ b/scala/scala-2.12/Dockerfile
@@ -1,0 +1,25 @@
+FROM amazoncorretto:11
+
+ENV SCALA_VERSION=2.12.8
+ENV LANG C.UTF-8
+
+RUN curl https://bintray.com/sbt/rpm/rpm | tee /etc/yum.repos.d/bintray-sbt-rpm.repo
+
+RUN yum install -y nginx procps tar gzip sbt && yum clean all
+
+# set up flyway for runtime migrations
+ADD https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/6.0.0/flyway-commandline-6.0.0-linux-x64.tar.gz /tmp/flyway.tar.gz
+
+RUN mkdir -p /opt/flyway && \
+  tar zxf /tmp/flyway.tar.gz -C /opt/flyway --strip-components=1 \
+  && chmod 755 /opt/flyway/flyway
+
+RUN cd /tmp && \
+    curl -q -L -O https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz && \
+    tar -zxf scala-${SCALA_VERSION}.tgz -C /usr/local
+
+ENV PATH=/usr/local/scala-$SCALA_VERSION/bin:$PATH
+
+# run these commands to make sure all SBT and Scala JARs are downloaded
+RUN scala -version && \
+    sbt about

--- a/scala/scala-2.12/Dockerfile.node
+++ b/scala/scala-2.12/Dockerfile.node
@@ -1,0 +1,5 @@
+FROM artsy/scala:2.12
+
+RUN curl --silent --location https://rpm.nodesource.com/setup_10.x | bash -
+RUN yum -y install nodejs python2 python2-pip && yum clean all
+RUN pip2 install hokusai

--- a/scala/scala-2.12/README.md
+++ b/scala/scala-2.12/README.md
@@ -1,0 +1,18 @@
+# SBT/Corretto image
+
+This image is based on [Amazon Corretto](https://hub.docker.com/_/amazoncorretto),
+and contains [Scala](http://www.scala-lang.org/) and [sbt](https://www.scala-sbt.org/).
+
+Build and deploy to Docker Hub using `./build.sh`.
+
+## Usage Example
+
+```Dockerfile
+FROM artsy/scala:2.12
+```
+
+For running using  [hokusai](https://github.com/artsy/hokusai) or CircleCI
+
+```Dockerfile
+FROM artsy/scala:2.12-node
+```

--- a/scala/scala-2.12/build.sh
+++ b/scala/scala-2.12/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker build -t artsy/scala:2.12 .
+docker build -t artsy/scala:2.12-node -f Dockerfile.node .
+docker login
+docker push artsy/scala:2.12
+docker push artsy/scala:2.12-node


### PR DESCRIPTION
We're trying out the latest Corretto version (11). They now have an official image based on Amazon Linux.

I have already pushed these to [Docker Hub](https://cloud.docker.com/u/artsy/repository/docker/artsy/scala).

I'll do some cleanup of Java/Scala directories once we know this works OK.