### PR TITLE
Remove ambiguous arg

### DIFF
--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -33,7 +33,7 @@ fi
 start_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Starting at $start_datetime"
 
-pg_dump -O -Fc -d $DATABASE_URL -f archive.pgdump ${@:2}
+pg_dump -O -Fc -d $DATABASE_URL -f archive.pgdump
 
 aws s3 cp archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
 

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -35,7 +35,7 @@ echo "[data export] Starting at $start_datetime"
 
 aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump archive.pgdump
 
-pg_restore archive.pgdump -O -x -d $DATABASE_URL ${@:2}
+pg_restore archive.pgdump -O -x -d $DATABASE_URL
 
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Ended at $end_datetime"


### PR DESCRIPTION
This script was failing when triggered in Kubernetes with the following error:
<img width="772" alt="Screen Shot 2019-12-19 at 12 11 50 PM" src="https://user-images.githubusercontent.com/1497424/71197773-5961ae00-2260-11ea-89e0-eee8744e7318.png">

This PR removes second argument to `export-db` script, which matches it to a functional, existing dump script here: https://github.com/artsy/galaxy-api/blob/master/data-sync/export-db.sh#L6

I was able to run the script locally and get a successful pg archive. 