### PR TITLE
Update pg data sync

### DIFF
--- a/pg-data-sync/Dockerfile
+++ b/pg-data-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:9.5
 
 RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/pg-data-sync/README.md
+++ b/pg-data-sync/README.md
@@ -12,8 +12,12 @@ Set the env vars `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` with credential
 
 ## Export
 
-Invoke `./export-db.sh` with the name of the archive (i.e. "staging" or "latest") to create in S3 - additional arguments are passed to `pg_dump`
+- Invoke `./export-db.sh` with the name of the archive as an argument (i.e. "staging" or "latest") providing the filename to create in S3.
+
+- Optionally provide a second argument as a quoted string to override the default export options "-O -Fc"
 
 ## Import
 
-Invoke `./import-db.sh` with the name of the archive (i.e. "staging" or "latest") to restore from S3 - additional arguments are passed to `pg_restore`
+- Invoke `./import-db.sh` with the name of the archive as an argument (i.e. "staging" or "latest") providing the filename to restore from S3.
+
+- Optionally provide a second argument as a quoted string to override the default import options "--clean --no-owner --no-privileges --schema=public"

--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -12,6 +12,13 @@ fi
 
 ARCHIVE_NAME=$1
 
+if test -z "$2"
+then
+  PG_DUMP_ARGS="-O -Fc"
+else
+  PG_DUMP_ARGS=$2
+fi
+
 if test -z "$DATABASE_URL"
 then
   echo "This script creates an archive from DATABASE_URL so it must be set!"
@@ -33,7 +40,7 @@ fi
 start_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Starting at $start_datetime"
 
-pg_dump -O -Fc -d $DATABASE_URL -f archive.pgdump
+pg_dump -d $DATABASE_URL -f archive.pgdump $PG_DUMP_ARGS
 
 aws s3 cp archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
 

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -14,7 +14,7 @@ ARCHIVE_NAME=$1
 
 if test -z "$2"
 then
-  PG_RESTORE_ARGS="--clean --no-owner --no-privileges"
+  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public"
 else
   PG_RESTORE_ARGS=$2
 fi

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: ./export-db.sh { ARCHIVE_NAME } { PG_RESTORE_ARGS }
+# Usage: ./import-db.sh { ARCHIVE_NAME } { PG_RESTORE_ARGS }
 
 set -e
 
@@ -11,6 +11,13 @@ then
 fi
 
 ARCHIVE_NAME=$1
+
+if test -z "$2"
+then
+  PG_RESTORE_ARGS="--clean --no-owner --no-privileges"
+else
+  PG_RESTORE_ARGS=$2
+fi
 
 if test -z "$DATABASE_URL"
 then
@@ -35,7 +42,7 @@ echo "[data export] Starting at $start_datetime"
 
 aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump archive.pgdump
 
-pg_restore archive.pgdump --clean --no-owner --no-privileges -d $DATABASE_URL
+pg_restore archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Ended at $end_datetime"


### PR DESCRIPTION
- Fix overriding pg_dump and pg_restore args as a second argument provided to scripts.
- Downgrade to v9.5 of the tools... this should fix `could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"` errors on restore  (Perhaps we should maintain separate tags going forward, but for our uses this should work with our RDS databases...)  
- Add the flag `--schema=public` to the default `pg_restore` args - this should fix all erros trying to drop / recreate or modify the public schema on restore.