### PR TITLE
Improve safety of data import job

### DIFF
--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -14,7 +14,7 @@ ARCHIVE_NAME=$1
 
 if test -z "$2"
 then
-  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public"
+  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public --data-only"
 else
   PG_RESTORE_ARGS=$2
 fi


### PR DESCRIPTION
Rather than clobbering the schema, this flag should ensure we only deal with importing data. This came up when convection staging and production schemas were out of sync and import jobs were clobbering the staging schema leaving us in a weird state.