### PR TITLE
add sidekiq-migrate

### DIFF
--- a/sidekiq-migrate/Dockerfile
+++ b/sidekiq-migrate/Dockerfile
@@ -4,4 +4,4 @@ RUN gem install redis json
 
 COPY migrate.rb /migrate.rb
 
-CMD ["ruby" "migrate.rb"]
+CMD ["/usr/local/bin/ruby" "/migrate.rb"]

--- a/sidekiq-migrate/Dockerfile
+++ b/sidekiq-migrate/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.6.2
+
+RUN gem install redis json
+
+COPY migrate.rb /migrate.rb
+
+CMD ["ruby" "migrate.rb"]

--- a/sidekiq-migrate/README.md
+++ b/sidekiq-migrate/README.md
@@ -1,0 +1,24 @@
+# Sidekiq Migrate
+
+Dockerfile and scripts for migrating Sidekiq queues from an old to new Redis instance
+
+## Use
+
+Default Dockerfile command: `ruby migrate.rb`
+
+### Required enviornment variables:
+
+- `SIDEKIQ_OLD_REDIS_URL`
+- `SIDEKIQ_NEW_REDIS_URL`
+
+If *only* these are supplied, `migrate.rb` will make a dry run
+
+### Optional enviornment variables:
+
+- `ACTUAL_RUN`
+
+If set to "true", `migrate.rb` will copy all queues and retry / scheduled sets to the new Redis instance
+
+- `CLEAN_UP`
+
+If also set to "true", `migrate.rb` will remove they keys in the old Redis (only applies when `ACTUAL_RUN` is also true)

--- a/sidekiq-migrate/migrate.rb
+++ b/sidekiq-migrate/migrate.rb
@@ -1,0 +1,58 @@
+require "redis"
+require "json"
+
+start_time = Time.now.to_f
+
+actual_run = (ENV['ACTUAL_RUN'].to_s.downcase == 'true') # actutally migrate keys
+clean_up = (ENV['CLEAN_UP'].to_s.downcase == 'true') # clean up keys in old redis (only applies if actual_run is also true)
+
+old_redis = Redis.new(url: ENV.fetch('SIDEKIQ_OLD_REDIS_URL'))
+new_redis = Redis.new(url: ENV.fetch('SIDEKIQ_NEW_REDIS_URL'))
+
+old_redis.smembers('queues').each do |q|
+  puts "Migrating queue #{q}..."
+
+  moved_jobs_counter = Hash.new(0)
+  rqn = "queue:#{q}"
+
+  if actual_run and clean_up
+    old_redis.llen(rqn).times do
+      job_json = old_redis.rpop(rqn)
+      new_redis.lpush(rqn, job_json)
+      job_hash = JSON.parse(job_json)
+      moved_jobs_counter[job_hash['class']] += 1
+    end
+  else
+    queue_items = old_redis.lrange(rqn, 0, -1)
+    queue_items.each do |job_json|
+      new_redis.lpush(rqn, job_json) if actual_run
+      job_hash = JSON.parse(job_json)
+      moved_jobs_counter[job_hash['class']] += 1
+    end
+  end
+
+  puts "Queue [#{q}] moved:"
+  moved_jobs_counter.each { |k, c| puts "  #{k} => #{c}" }
+  puts "Queue [#{q}] remaining_jobs: #{old_redis.llen(rqn)}"
+end
+
+%w[retry schedule].each do |set_type|
+  puts "Migrating set #{set_type}..."
+
+  moved_jobs_counter = Hash.new(0)
+  set_jobs = old_redis.zrange(set_type, 0, -1, with_scores: true)
+
+  set_jobs.each do |job_json, run_at|
+    new_redis.zadd(set_type, run_at, job_json) if actual_run
+    old_redis.zrem(set_type, job_json) if actual_run and clean_up
+    job_hash = JSON.parse(job_json)
+    moved_jobs_counter[job_hash['class']] += 1
+  end
+
+  puts "JobSet [#{set_type}] moved:"
+  moved_jobs_counter.each { |k, c| puts "  #{k} => #{c}" }
+  puts "JobSet [#{set_type}] remaining jobs: #{old_redis.zrange(set_type, 0, -1).size}"
+end
+
+time_taken_ms = (1000 * (Time.now.to_f - start_time)).ceil
+puts "Completed migration in #{time_taken_ms} milliseconds."

--- a/sidekiq-migrate/migrate.rb
+++ b/sidekiq-migrate/migrate.rb
@@ -3,11 +3,15 @@ require "json"
 
 start_time = Time.now.to_f
 
-actual_run = (ENV['ACTUAL_RUN'].to_s.downcase == 'true') # actutally migrate keys
-clean_up = (ENV['CLEAN_UP'].to_s.downcase == 'true') # clean up keys in old redis (only applies if actual_run is also true)
-
 old_redis = Redis.new(url: ENV.fetch('SIDEKIQ_OLD_REDIS_URL'))
 new_redis = Redis.new(url: ENV.fetch('SIDEKIQ_NEW_REDIS_URL'))
+
+actual_run = (ENV['ACTUAL_RUN'].to_s.downcase == 'true') # actutally migrate keys
+clean_up = (ENV['CLEAN_UP'].to_s.downcase == 'true') # clean up keys in old redis (only applies if actual_run is also true)
+debug = (ENV['DEBUG'].to_s.downcase == 'true')
+
+puts "Migrating from #{old_redis} to #{new_redis}"
+puts "=== DRY RUN ===" unless actual_run
 
 old_redis.smembers('queues').each do |q|
   puts "Migrating queue #{q}..."
@@ -18,16 +22,16 @@ old_redis.smembers('queues').each do |q|
   if actual_run and clean_up
     old_redis.llen(rqn).times do
       job_json = old_redis.rpop(rqn)
+      puts job_json if debug
       new_redis.lpush(rqn, job_json)
-      job_hash = JSON.parse(job_json)
-      moved_jobs_counter[job_hash['class']] += 1 if actual_run
+      moved_jobs_counter[JSON.parse(job_json)['class']] += 1
     end
   else
     queue_items = old_redis.lrange(rqn, 0, -1)
     queue_items.each do |job_json|
+      puts job_json if debug
       new_redis.lpush(rqn, job_json) if actual_run
-      job_hash = JSON.parse(job_json)
-      moved_jobs_counter[job_hash['class']] += 1 if actual_run
+      moved_jobs_counter[JSON.parse(job_json)['class']] += 1 if actual_run
     end
   end
 
@@ -43,10 +47,10 @@ end
   set_jobs = old_redis.zrange(set_type, 0, -1, with_scores: true)
 
   set_jobs.each do |job_json, run_at|
+    puts job_json if debug
     new_redis.zadd(set_type, run_at, job_json) if actual_run
     old_redis.zrem(set_type, job_json) if actual_run and clean_up
-    job_hash = JSON.parse(job_json)
-    moved_jobs_counter[job_hash['class']] += 1 if actual_run
+    moved_jobs_counter[JSON.parse(job_json)['class']] += 1 if actual_run
   end
 
   puts "JobSet [#{set_type}] moved:"

--- a/sidekiq-migrate/migrate.rb
+++ b/sidekiq-migrate/migrate.rb
@@ -36,7 +36,7 @@ old_redis.smembers('queues').each do |q|
   puts "Queue [#{q}] remaining_jobs: #{old_redis.llen(rqn)}"
 end
 
-%w[retry schedule].each do |set_type|
+%w[retry schedule dead].each do |set_type|
   puts "Migrating set #{set_type}..."
 
   moved_jobs_counter = Hash.new(0)

--- a/sidekiq-migrate/migrate.rb
+++ b/sidekiq-migrate/migrate.rb
@@ -20,14 +20,14 @@ old_redis.smembers('queues').each do |q|
       job_json = old_redis.rpop(rqn)
       new_redis.lpush(rqn, job_json)
       job_hash = JSON.parse(job_json)
-      moved_jobs_counter[job_hash['class']] += 1
+      moved_jobs_counter[job_hash['class']] += 1 if actual_run
     end
   else
     queue_items = old_redis.lrange(rqn, 0, -1)
     queue_items.each do |job_json|
       new_redis.lpush(rqn, job_json) if actual_run
       job_hash = JSON.parse(job_json)
-      moved_jobs_counter[job_hash['class']] += 1
+      moved_jobs_counter[job_hash['class']] += 1 if actual_run
     end
   end
 
@@ -46,7 +46,7 @@ end
     new_redis.zadd(set_type, run_at, job_json) if actual_run
     old_redis.zrem(set_type, job_json) if actual_run and clean_up
     job_hash = JSON.parse(job_json)
-    moved_jobs_counter[job_hash['class']] += 1
+    moved_jobs_counter[job_hash['class']] += 1 if actual_run
   end
 
   puts "JobSet [#{set_type}] moved:"


### PR DESCRIPTION
Script to migrate Sidekiq queues from one Redis to another.

I sourced the idea from https://github.com/mperham/sidekiq/issues/3900#issuecomment-410104469 then refactored a bit.

My first try migrating Convection staging, all scheduled jobs were executed immediately.  So I dropped the Sidekiq dependency in the source code, and dropped down a level to migrate everything using only Redis commands.

Also refactored so that keys remain in place in the old Redis, unless CLEAN_UP is supplied.

After testing importing to my local Redis, I felt bold, and ran the import on Convection production, knowing that without setting `CLEAN_UP=true` I could retry if anything went wrong.  But it didn't!  And you can now see all retry / scheduled jobs that were on our previous Redis instance in https://convection.artsy.net/admin/sidekiq/retries

No need now for creating a "legacy" Sidekiq deployment as in https://github.com/artsy/convection/pull/416 - we can simply update the Redis URL, then run this script to move any existing jobs to the new Redis