### PR TITLE
Redis migrate

### DIFF
--- a/redis-migrate/Dockerfile
+++ b/redis-migrate/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2
+
+RUN pip install redis termcolor
+
+ADD migrate.py /
+
+ENTRYPOINT ["/usr/local/bin/python", "/migrate.py"]
+CMD ["-h"]

--- a/redis-migrate/README.md
+++ b/redis-migrate/README.md
@@ -1,0 +1,20 @@
+# Easy peasy Redis migration
+
+Utility for migrating all Redis keys to a new instance when you can't use MIGRATE ... I'm lookin' at you AWS >:(
+
+## Use
+
+`docker run artsy/redis-migrate:latest` `SOURCE_REDIS` `DESTINATION_REDIS`
+
+`SOURCE_REDIS` / `DESTINATION_REDIS` should be in the form of `host:port/database`, i.e. `localhost:6379/0`
+
+### Additional environment options
+
+Set the env var `DEBUG=1` to enable debug logging
+
+Set the env var `DRY_RUN=1` to make a dry run
+
+Set the env var `REPLACE_DST_KEYS=1` to force overwrite of keys in the destination database - otherwise if a key already exists, restore fails to overwrite an existing key and an error message is printed
+
+
+Credit goes to @josegonzalez for the source code in [this gist](https://gist.github.com/josegonzalez/6049a72cb163337a18102743061dfcac) - just made some slight tweaks and packaged it up here so to be able to run in container environments

--- a/redis-migrate/migrate.py
+++ b/redis-migrate/migrate.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+import redis
+from termcolor import cprint
+
+DEBUG = os.environ.get("DEBUG")
+DRY_RUN = os.environ.get("DRY_RUN")
+
+if os.environ.get("REPLACE_DST_KEYS"):
+    REPLACE_DST_KEYS = True
+else:
+    REPLACE_DST_KEYS = False
+
+def connect_redis(conn_dict):
+    conn = redis.StrictRedis(host=conn_dict['host'],
+                             port=conn_dict['port'],
+                             db=conn_dict['db'])
+    return conn
+
+
+def conn_string_type(string):
+    format = '<host>:<port>/<db>'
+    try:
+        host, portdb = string.split(':')
+        port, db = portdb.split('/')
+        db = int(db)
+    except ValueError:
+        raise argparse.ArgumentTypeError('incorrect format, should be: %s' % format)
+    return {'host': host,
+            'port': port,
+            'db': db}
+
+
+def migrate_redis(source, destination):
+    cprint("Migrating %s:%s/%s to %s:%s/%s..." % (source['host'], source['port'], source['db'], destination['host'], destination['port'], destination['db']), 'green')
+    src = connect_redis(source)
+    dst = connect_redis(destination)
+    keys = src.keys('*')
+    errors = 0
+    for key in keys:
+        ttl = src.ttl(key)
+        # we handle TTL command returning -1 (no expire) or -2 (no key)
+        if ttl < 0:
+            ttl = 0
+        if DEBUG or DRY_RUN:
+            cprint("Dumping key: %s with TTL %ss" % (key, ttl), 'yellow')
+        value = src.dump(key)
+        if DEBUG or DRY_RUN:
+            cprint("Restoring key: %s with TTL %sms" % (key, ttl * 1000), 'yellow')
+        if not DRY_RUN:
+            try:
+                # TTL command returns the key's ttl value in seconds but restore expects it in milliseconds!
+                dst.restore(key, ttl * 1000, value, replace=REPLACE_DST_KEYS)
+            except redis.exceptions.ResponseError:
+                cprint("! Failed to restore key: %s" % key, 'red')
+                errors += 1
+                pass
+    cprint("Migrated %d keys" % (len(keys) - errors), 'green')
+
+
+def run():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('source', type=conn_string_type)
+    parser.add_argument('destination', type=conn_string_type)
+    options = parser.parse_args()
+    migrate_redis(options.source, options.destination)
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
Docker image to migrate all keys in Redis database as AWS Elasticache Redis deployments [don't allow](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/RestrictedCommands.html) using the Redis [MIGRATE command](https://redis.io/commands/migrate)