### PR TITLE
Updates to Redis migrate

### DIFF
--- a/redis-migrate/README.md
+++ b/redis-migrate/README.md
@@ -16,5 +16,7 @@ Set the env var `DRY_RUN=1` to make a dry run
 
 Set the env var `REPLACE_DST_KEYS=1` to force overwrite of keys in the destination database - otherwise if a key already exists, restore fails to overwrite an existing key and an error message is printed
 
+Set the env var `CLEAN_UP=1` to delete keys in the source database if sucessfully migrated to the destination database
+
 
 Credit goes to @josegonzalez for the source code in [this gist](https://gist.github.com/josegonzalez/6049a72cb163337a18102743061dfcac) - just made some slight tweaks and packaged it up here so to be able to run in container environments

--- a/redis-migrate/README.md
+++ b/redis-migrate/README.md
@@ -4,9 +4,9 @@ Utility for migrating all Redis keys to a new instance when you can't use MIGRAT
 
 ## Use
 
-`docker run artsy/redis-migrate:latest` `SOURCE_REDIS` `DESTINATION_REDIS`
+`docker run artsy/redis-migrate:latest` `SOURCE_REDIS_URL` `DESTINATION_REDIS_URL`
 
-`SOURCE_REDIS` / `DESTINATION_REDIS` should be in the form of `host:port/database`, i.e. `localhost:6379/0`
+`SOURCE_REDIS_URL` / `DESTINATION_REDIS_URL` should be in the form of `redis://host:port/database`, i.e. `redis://localhost:6379/0`
 
 ### Additional environment options
 

--- a/redis-migrate/migrate.py
+++ b/redis-migrate/migrate.py
@@ -8,6 +8,7 @@ from termcolor import cprint
 
 DEBUG = os.environ.get("DEBUG")
 DRY_RUN = os.environ.get("DRY_RUN")
+CLEAN_UP = os.environ.get("CLEAN_UP")
 
 if os.environ.get("REPLACE_DST_KEYS"):
     REPLACE_DST_KEYS = True
@@ -78,7 +79,10 @@ def migrate_redis(source, destination):
             except (redis.exceptions.ResponseError, redis.exceptions.DataError):
                 cprint("! Failed to restore key: %s" % key, 'red')
                 errors += 1
-                pass
+                continue # Don't delete the key in src if it failed to restore - move on to the next iteration
+            if CLEAN_UP:
+                src.delete(key)
+
     if DRY_RUN:
         cprint("Migrated %d keys" % (len(keys) - errors), 'yellow')
     else:

--- a/redis-migrate/migrate.py
+++ b/redis-migrate/migrate.py
@@ -84,7 +84,7 @@ def migrate_redis(source, destination):
                 src.delete(key)
 
     if DRY_RUN:
-        cprint("Migrated %d keys" % (len(keys) - errors), 'yellow')
+        cprint("Migrated %d keys << DRY RUN >>" % (len(keys) - errors), 'yellow')
     else:
         cprint("Migrated %d keys" % (len(keys) - errors), 'green')
 

--- a/redis-migrate/migrate.py
+++ b/redis-migrate/migrate.py
@@ -53,7 +53,7 @@ def migrate_redis(source, destination):
             try:
                 # TTL command returns the key's ttl value in seconds but restore expects it in milliseconds!
                 dst.restore(key, ttl * 1000, value, replace=REPLACE_DST_KEYS)
-            except redis.exceptions.ResponseError:
+            except (redis.exceptions.ResponseError, redis.exceptions.DataError):
                 cprint("! Failed to restore key: %s" % key, 'red')
                 errors += 1
                 pass

--- a/redis-migrate/migrate.py
+++ b/redis-migrate/migrate.py
@@ -52,7 +52,10 @@ def conn_string_type(string):
 
 
 def migrate_redis(source, destination):
-    cprint("Migrating %s:%s/%s to %s:%s/%s..." % (source['host'], source['port'], source['db'], destination['host'], destination['port'], destination['db']), 'green')
+    if DRY_RUN:
+        cprint("Migrating %s:%s/%s to %s:%s/%s << DRY RUN >>..." % (source['host'], source['port'], source['db'], destination['host'], destination['port'], destination['db']), 'yellow')
+    else:
+        cprint("Migrating %s:%s/%s to %s:%s/%s..." % (source['host'], source['port'], source['db'], destination['host'], destination['port'], destination['db']), 'green')
 
     src = connect_redis(source)
     dst = connect_redis(destination)
@@ -63,10 +66,10 @@ def migrate_redis(source, destination):
         # we handle TTL command returning -1 (no expire) or -2 (no key)
         if ttl < 0:
             ttl = 0
-        if DEBUG or DRY_RUN:
+        if DEBUG:
             cprint("Dumping key: %s with TTL %ss" % (key, ttl), 'yellow')
         value = src.dump(key)
-        if DEBUG or DRY_RUN:
+        if DEBUG:
             cprint("Restoring key: %s with TTL %sms" % (key, ttl * 1000), 'yellow')
         if not DRY_RUN:
             try:
@@ -76,7 +79,10 @@ def migrate_redis(source, destination):
                 cprint("! Failed to restore key: %s" % key, 'red')
                 errors += 1
                 pass
-    cprint("Migrated %d keys" % (len(keys) - errors), 'green')
+    if DRY_RUN:
+        cprint("Migrated %d keys" % (len(keys) - errors), 'yellow')
+    else:
+        cprint("Migrated %d keys" % (len(keys) - errors), 'green')
 
 
 def run():


### PR DESCRIPTION
Trying to make this more consistent with out apps' connection string / sidekiq-migrate parameters and options

Also I encountered an error migrating Volt production:

```
Traceback (most recent call last):
  File "/migrate.py", line 71, in <module>
    run()
  File "/migrate.py", line 68, in run
    migrate_redis(options.source, options.destination)
  File "/migrate.py", line 55, in migrate_redis
    dst.restore(key, ttl * 1000, value, replace=REPLACE_DST_KEYS)
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 1487, in restore
    return self.execute_command('RESTORE', *params)
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 838, in execute_command
    conn.send_command(*args)
  File "/usr/local/lib/python2.7/site-packages/redis/connection.py", line 686, in send_command
    self.send_packed_command(self.pack_command(*args),
  File "/usr/local/lib/python2.7/site-packages/redis/connection.py", line 737, in pack_command
    for arg in imap(self.encoder.encode, args):
  File "/usr/local/lib/python2.7/site-packages/redis/connection.py", line 118, in encode
    "byte, string or number first." % typename)
redis.exceptions.DataError: Invalid input of type: 'NoneType'. Convert to a byte, string or number first.
```

The key `volt:session:17ece8977eec903df3ddb10027739360` was `(nil)` in Redis and cast to `None` in Python, throwing [redis.exceptions.DataError](https://github.com/andymccurdy/redis-py/blob/master/redis/connection.py#L120).  (nil) is returned by a non-existent key so likely caused by a race condition where Volt production deleted the key while the restore operation was taking place.  I don't think this script can guard against such race conditions for a live application, so catch this error, print a warning and move on.

Changes:

- Catch restore errors `redis.exceptions.DataError`
- Use `urlparse` to require `redis://` URL scheme and default to port 6379 and db 0 if not supplied
- Add `CLEAN_UP` env var
- Update `DRY_RUN` / `DEBUG` output
