### PR TITLE
Dockerize Mongo db-sync

### DIFF
--- a/mongo-data-sync/Dockerfile
+++ b/mongo-data-sync/Dockerfile
@@ -1,0 +1,8 @@
+FROM mongo:4.0
+
+RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD export-mongo.sh .
+ADD import-mongo.sh .
+
+CMD ["sh", "./export-mongo.sh", "latest"]

--- a/mongo-data-sync/README.md
+++ b/mongo-data-sync/README.md
@@ -1,6 +1,6 @@
 # Mongo Data-Sync
 
-Dockerfile and scripts for exporting and importing Postgres databases
+Dockerfile and scripts for exporting and importing Mongo databases
 
 # Use
 

--- a/mongo-data-sync/README.md
+++ b/mongo-data-sync/README.md
@@ -2,6 +2,8 @@
 
 Dockerfile and scripts for exporting and importing Mongo databases
 
+Changes to this directory must be [built and pushed to Docker Hub](https://github.com/artsy/docker-images#adding-an-image-to-docker-hub).
+
 # Use
 
 Set the env var `APP_NAME` to the name of your application

--- a/mongo-data-sync/README.md
+++ b/mongo-data-sync/README.md
@@ -1,0 +1,19 @@
+# Mongo Data-Sync
+
+Dockerfile and scripts for exporting and importing Postgres databases
+
+# Use
+
+Set the env var `APP_NAME` to the name of your application
+
+Set the env var `MONGOHQ_URL` to a Mongo connection string pointing to the target database
+
+Set the env vars `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` with credentials to upload archives to S3
+
+## Export
+
+- Invoke `./export-db.sh` with the name of the archive as an argument (i.e. "staging" or "latest") providing the filename to create in S3.
+
+## Import
+
+- Invoke `./import-db.sh` with the name of the archive as an argument (i.e. "staging" or "latest") providing the filename to restore from S3.

--- a/mongo-data-sync/export-db.sh
+++ b/mongo-data-sync/export-db.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Usage: ./export-db.sh { ARCHIVE_NAME }
+
+set -e
+
+if test -z "$1"
+then
+  echo "You must supply an archive name as an argument"
+  exit 1
+fi
+
+ARCHIVE_NAME=$1
+
+if test -z "$MONGOHQ_URL"
+then
+  echo "This script creates an archive from MONGOHQ_URL so it must be set!"
+  exit 1
+fi
+
+if test -z "$APP_NAME"
+then
+  echo "This script creates an archive for APP_NAME so it must be set!"
+  exit 1
+fi
+
+if test -z "$AWS_ACCESS_KEY_ID" || test -z "$AWS_SECRET_ACCESS_KEY"
+then
+  echo "AWS credentials must be set!"
+  exit 1
+fi
+
+start_datetime=$(date -u +"%D %T %Z")
+echo "[data export] Starting at $start_datetime"
+
+mongodump --uri="$MONGOHQ_URL" --gzip --archive=archive.tar.gz
+
+aws s3 cp archive.tar.gz s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.tar.gz
+
+end_datetime=$(date -u +"%D %T %Z")
+echo "[data export] Ended at $end_datetime"

--- a/mongo-data-sync/import-db.sh
+++ b/mongo-data-sync/import-db.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Usage: ./import-db.sh { ARCHIVE_NAME }
+
+set -e
+
+if test -z "$1"
+then
+  echo "You must supply an archive name as an argument"
+  exit 1
+fi
+
+ARCHIVE_NAME=$1
+
+if test -z "$MONGOHQ_URL"
+then
+  echo "This script restores an archive from MONGOHQ_URL so it must be set!"
+  exit 1
+fi
+
+if test -z "$APP_NAME"
+then
+  echo "This script restores an archive for APP_NAME so it must be set!"
+  exit 1
+fi
+
+if test -z "$AWS_ACCESS_KEY_ID" || test -z "$AWS_SECRET_ACCESS_KEY"
+then
+  echo "AWS credentials must be set!"
+  exit 1
+fi
+
+start_datetime=$(date -u +"%D %T %Z")
+echo "[data import] Starting at $start_datetime"
+
+aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.tar.gz archive.tar.gz
+
+mongorestore --uri="$MONGOHQ_URL" --stopOnError --drop --gzip --archive=archive.tar.gz
+
+end_datetime=$(date -u +"%D %T %Z")
+echo "[data import] Ended at $end_datetime"

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -38,11 +38,11 @@ then
 fi
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[data export] Starting at $start_datetime"
+echo "[data import] Starting at $start_datetime"
 
 aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump archive.pgdump
 
 pg_restore archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[data export] Ended at $end_datetime"
+echo "[data import] Ended at $end_datetime"


### PR DESCRIPTION
Dockerizes the Mongo db sync used by Positron, so we can reuse on other db's and easily reference preferred strategy in docs. 
This PR updates the existing script from Positron to more closely match the error handling in the PG equivalent-- for example telling you if an env var is missing.

Related to https://artsyproduct.atlassian.net/browse/PLATFORM-2223
