### PR TITLE
Update pg-data-sync images

### DIFF
--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -14,7 +14,7 @@ ARCHIVE_NAME=$1
 
 if test -z "$2"
 then
-  PG_DUMP_ARGS="-O -Fc"
+  PG_DUMP_ARGS="-O -Fc -v"
 else
   PG_DUMP_ARGS=$2
 fi

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -14,7 +14,7 @@ ARCHIVE_NAME=$1
 
 if test -z "$2"
 then
-  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public"
+  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public -v"
 else
   PG_RESTORE_ARGS=$2
 fi

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -2,8 +2,6 @@
 
 # Usage: ./import-db.sh { ARCHIVE_NAME } { PG_RESTORE_ARGS }
 
-set -e
-
 if test -z "$1"
 then
   echo "You must supply an archive name as an argument"
@@ -46,3 +44,9 @@ pg_restore archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data import] Ended at $end_datetime"
+
+if [ "$SWALLOW_ERRORS_ON_RESTORE" = "1" ]; then
+  exit 0
+else
+  exit $?
+fi


### PR DESCRIPTION
Add verbose output by default and introduce the `SWALLOW_ERRORS_ON_RESTORE` env var so a Kubernetes job running a 1-off pod import, for instance, exits cleanly