### PR TITLE
generate Docker images for Postgres versions 9-12 

### DIFF
--- a/pg-data-sync/.gitignore
+++ b/pg-data-sync/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/pg-data-sync/Dockerfile
+++ b/pg-data-sync/Dockerfile
@@ -1,8 +1,0 @@
-FROM postgres:9.5
-
-RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ADD export-db.sh .
-ADD import-db.sh .
-
-CMD ["sh", "./export-db.sh", "latest"]

--- a/pg-data-sync/build.sh
+++ b/pg-data-sync/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Use: ./build.sh
+
+build_version () {
+  cat <<EOF > Dockerfile
+FROM postgres:$1
+
+RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ADD export-db.sh .
+ADD import-db.sh .
+
+CMD ["sh", "./export-db.sh", "latest"]
+EOF
+
+docker build -t artsy/pg-data-sync .
+docker tag artsy/pg-data-sync:latest artsy/pg-data-sync:$1
+docker push artsy/pg-data-sync:$1
+
+}
+
+build_version '9.5'
+build_version '9.6'
+build_version '10'
+build_version '11'
+build_version '12'

--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -40,9 +40,14 @@ fi
 start_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Starting at $start_datetime"
 
-pg_dump -d $DATABASE_URL -f archive.pgdump $PG_DUMP_ARGS
+pg_dump -d $DATABASE_URL -f /tmp/archive.pgdump $PG_DUMP_ARGS
 
-aws s3 cp archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
+if [ "$USE_ARCHIVE_TIMESTAMP" = "1" ]; then
+  timestamp=`date +%m-%d-%Y--%l-%M-%S`
+  aws s3 cp /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
+else
+  aws s3 cp /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
+fi
 
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data export] Ended at $end_datetime"

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -38,9 +38,9 @@ fi
 start_datetime=$(date -u +"%D %T %Z")
 echo "[data import] Starting at $start_datetime"
 
-aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump archive.pgdump
+aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump /tmp/archive.pgdump
 
-pg_restore archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
+pg_restore /tmp/archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data import] Ended at $end_datetime"


### PR DESCRIPTION
- Update pg-data-sync to generate Dockerfiles for Postgres versions 9-12 and publish to ECR
- Add option to specify `USE_ARCHIVE_TIMESTAMP` so as to generate a specific point-in-time archive and save to S3 (this can be passed into the restore script)
- Update scripts to save archive file to /tmp so we can attach a persistent volume when generating or restoring large backups