### PR TITLE
Add image for Ruby 2.7.1

### DIFF
--- a/ruby/2.7.1-node-chrome/Dockerfile
+++ b/ruby/2.7.1-node-chrome/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.7.1
+
+# Install NodeJS apt sources
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+# Add Chrome source
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+
+RUN apt-get update -qq
+RUN apt-get install -y nodejs libnss3 libgconf-2-4 google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Disable Chrome sandbox
+RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+
+RUN gem update --system
+RUN gem install bundler
+
+RUN npm install -g yarn


### PR DESCRIPTION
Not much to see here, just a copy/paste from the 2.7.0 Dockerfile to bump the patch-level of Ruby.