### PR TITLE
#MIGRATON fix: catch pg_restore exit code to use at the end.

### DIFF
--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -42,11 +42,13 @@ aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump /tmp/archive.pgdump
 
 pg_restore /tmp/archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 
+PG_EXIT_CODE=$?
+
 end_datetime=$(date -u +"%D %T %Z")
 echo "[data import] Ended at $end_datetime"
 
 if [ "$SWALLOW_ERRORS_ON_RESTORE" = "1" ]; then
   exit 0
 else
-  exit $?
+  exit $PG_EXIT_CODE
 fi


### PR DESCRIPTION
`exit $?` in the `if` statement at the end just returns the result of the if (0 if true, 1 if not). I think the intention is to return the exit code of pg_restore.

this possibly explains this jenkins job's failed status:

https://joe.artsy.net/job/gravity-staging-weekly-cron2/15/console

Migration
---
Update docker image.