### PR TITLE
feat: reduce verbosity of pg-data-sync output.

### DIFF
--- a/pg-data-sync/build.sh
+++ b/pg-data-sync/build.sh
@@ -3,10 +3,22 @@
 # Use: ./build.sh
 
 build_version () {
+
+  APT_PACKAGES="python3 curl"
+
+  if [[ $1 == '12' ]]
+  then
+    APT_PACKAGES=$APT_PACKAGES" python3-distutils"
+  fi
+
   cat <<EOF > Dockerfile
 FROM postgres:$1
 
-RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -qq && apt-get install -y $APT_PACKAGES && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -O https://bootstrap.pypa.io/get-pip.py
+RUN python3 get-pip.py
+RUN pip3 install awscli --upgrade
 
 ADD export-db.sh .
 ADD import-db.sh .

--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -38,16 +38,25 @@ then
 fi
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[data export] Starting at $start_datetime"
+echo "[pg_dump] Starting at $start_datetime"
 
 pg_dump -d $DATABASE_URL -f /tmp/archive.pgdump $PG_DUMP_ARGS
+ls -l /tmp/archive.pgdump
+
+end_datetime=$(date -u +"%D %T %Z")
+echo "[pg_dump] Ended at $end_datetime"
+
+start_datetime=$(date -u +"%D %T %Z")
+echo "[S3 upload] Starting at $start_datetime"
 
 if [ "$USE_ARCHIVE_TIMESTAMP" = "1" ]; then
   timestamp=`date +%m-%d-%Y--%l-%M-%S`
-  aws s3 cp /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
+  aws s3 cp --no-progress /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
+  aws s3 ls s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
 else
-  aws s3 cp /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
+  aws s3 cp --no-progress /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
+  aws s3 ls s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
 fi
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[data export] Ended at $end_datetime"
+echo "[S3 upload] Ended at $end_datetime"

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -36,16 +36,23 @@ then
 fi
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[data import] Starting at $start_datetime"
+echo "[S3 download] Starting at $start_datetime"
 
-aws s3 cp s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump /tmp/archive.pgdump
+aws s3 ls s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
+aws s3 cp ---no-progress s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump /tmp/archive.pgdump
+ls -l /tmp/archive.pgdump
+
+end_datetime=$(date -u +"%D %T %Z")
+echo "[S3 download] Ended at $end_datetime"
+
+start_datetime=$(date -u +"%D %T %Z")
+echo "[pg_restore] Starting at $start_datetime"
 
 pg_restore /tmp/archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
-
 PG_EXIT_CODE=$?
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[data import] Ended at $end_datetime"
+echo "[pg_restore] Ended at $end_datetime"
 
 if [ "$SWALLOW_ERRORS_ON_RESTORE" = "1" ]; then
   exit 0


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3059

https://joe.artsy.net/job/gravity-staging-weekly-cron2/15/console

The log is flooded with aws s3 cp's progress output:
```
Completed 471.8 MiB/553.0 MiB with 1 file(s) remaining
Completed 472.0 MiB/553.0 MiB with 1 file(s) remaining
```
Loading full log and searching through it (on Jenkins UI) takes a while I think b/c of so many of those lines. Suggest to suppress that output by adding `--no-progress` flag to aws s3 cp. To retain timing and size info, adding `ls` and separate timestamp for s3 download/upload.

If merged I will run ./build.sh to push up new images to dockerhub.

Related PR: https://github.com/artsy/gravity/pull/13747