### PR TITLE
chore: Set Alpine Version for Ruby, Node, Yarn

### DIFF
--- a/ruby/2.6.6-node-12-yarn/Dockerfile
+++ b/ruby/2.6.6-node-12-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine
+FROM ruby:2.6.6-alpine3.12
 
 # Install Node + Yarn
 ENV NODE_VERSION 12.20.1


### PR DESCRIPTION
Pins the alpine version to 3.12 which is what we have been using.