### PR TITLE
fix: work around expired ca cert

### DIFF
--- a/ruby/2.5.3-node-chrome/Dockerfile
+++ b/ruby/2.5.3-node-chrome/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.5.3
 
+# Work-around for expired root cert.
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 # Install NodeJS apt sources
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 

--- a/ruby/2.6.5-node-chrome/Dockerfile
+++ b/ruby/2.6.5-node-chrome/Dockerfile
@@ -1,5 +1,8 @@
 FROM ruby:2.6.5
 
+# Work-around for expired root cert.
+RUN sed -i '/^mozilla\/DST_Root_CA_X3/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
+
 # Install NodeJS apt sources
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3637
https://artsy.slack.com/archives/CP9P4KR35/p1633017320060100

[Ohm](https://app.circleci.com/pipelines/github/artsy/ohm/946/workflows/a3f75999-0097-43d7-af60-8dc1e527e9b5/jobs/1467) and [Currents](https://app.circleci.com/pipelines/github/artsy/currents/1493/workflows/ae61a4ca-735d-4169-9d02-67bc92b216c6/jobs/2202) builds are failing on nodesource due to [expired](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) CA cert `DST Root CA X3`.

Tried bunch of potential work-arounds. This PR adopts [this workaround](https://github.com/nodesource/distributions/issues/1266#issuecomment-933228467) as it seems the only one that works across Debian versions.

Implement this for only two artsy images because the others are likely not affected or not really being used.

Tested builds locally (as there's no CI):

```
jian@artsy:~/code/docker-images/ruby/2.5.3-node-chrome$ docker run -it docker-images/ruby-2.5.3-node-chrome-me bash
root@9c345c2b19c6:/# node --version
v8.17.0

jian@artsy:~/code/docker-images/ruby/2.6.5-node-chrome$ docker run -it docker-images/ruby-2.6.5-node-chrome-me bash
root@cee363667562:/#
root@cee363667562:/# node --version
v10.24.1
```
