### PR TITLE
[PLATFORM-3737]  Prevent pg_restore from raising error unnecessary errors

### DIFF
--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -12,7 +12,7 @@ ARCHIVE_NAME=$1
 
 if test -z "$2"
 then
-  PG_RESTORE_ARGS="--clean --no-owner --no-privileges --schema=public -v"
+  PG_RESTORE_ARGS="--clean --if-exists --no-owner --no-privileges --schema=public -v"
 else
   PG_RESTORE_ARGS=$2
 fi


### PR DESCRIPTION
[PLATFORM-3737] 

When running pg_restore with `-c`/`--clean` option, we want to also specify `--if-exists`, otherwise error messages are raised in case the destination database does not contain any objects

For reference, see:
https://www.postgresql.org/docs/12/app-pgdump.html

[PLATFORM-3737]: https://artsyproduct.atlassian.net/browse/PLATFORM-3737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ