### PR TITLE
[MIGRATION] feat: advance mongo client version to 4.2

### DIFF
--- a/mongo-data-sync/Dockerfile
+++ b/mongo-data-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.0
+FROM mongo:4.2
 
 RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3902

Staging mongo atlas cluster is at `4.2`. Production cluster is still at `4.0` but will be upgraded to `4.2` soon.

Bump the image here to `4.2` which I hope is (and it should be) backward compatible with `4.0` cluster.

This image is used by Kaws and Positron data-sync k8s cronjobs which pull the `latest` tag.

Migration (applied)
---
```
cd ./mongo-data-sync
docker build . -t artsy/mongo-data-sync:4.2
docker push artsy/mongo-data-sync:4.2
docker tag artsy/mongo-data-sync:4.2 artsy/mongo-data-sync:latest
docker push artsy/mongo-data-sync:latest
```