### PR TITLE
[MIGRATION] feat: advance mongo client version to 4.4

### DIFF
--- a/mongo-data-sync/Dockerfile
+++ b/mongo-data-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:4.2
+FROM mongo:4.4
 
 RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
like https://github.com/artsy/docker-images/pull/87, but for 4.4

production cluster has been upgraded to 4.4

Migration (applied)
---
```
cd ./mongo-data-sync
docker build . -t artsy/mongo-data-sync:4.4
docker push artsy/mongo-data-sync:4.4
docker tag artsy/mongo-data-sync:4.4 artsy/mongo-data-sync:latest
docker push artsy/mongo-data-sync:latest
```