### PR TITLE
feat: add ruby 2.7.3-node-chrome

### DIFF
--- a/ruby/2.7.3-node-chrome/Dockerfile
+++ b/ruby/2.7.3-node-chrome/Dockerfile
@@ -1,0 +1,20 @@
+FROM ruby:2.7.3
+
+# Install NodeJS apt sources
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+
+# Add Chrome source
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+
+RUN apt-get update -qq
+RUN apt-get install -y nodejs libnss3 libgconf-2-4 google-chrome-stable
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Disable Chrome sandbox
+RUN sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome"
+
+RUN gem update --system
+RUN gem install bundler
+
+RUN npm install -g yarn


### PR DESCRIPTION
Cuts a new `ruby` 2.7.3 version, with `node`.

This should solve some of the [noisy output problems](https://github.com/DataDog/dd-trace-rb/issues/1542#issuecomment-854463079) afflicting some apps running against ruby 2.7.1 

(I would have liked to bump all the way up to 2.7.6, but when I tried to do so I got cryptic errors about `npm` not being found 🤷🏽 ) 