### PR TITLE
chore: bump detect-secrets to v1.3.0

### DIFF
--- a/detect-secrets/Dockerfile
+++ b/detect-secrets/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 
 
-ARG toolVersion=1.2.0
+ARG toolVersion=1.3.0
 ARG ourVersion=1
 
 LABEL version="$toolVersion-$ourVersion"


### PR DESCRIPTION
This bumps the version to latest release.

[New tags already pushed](https://hub.docker.com/r/artsy/detect-secrets/tags).