### PR TITLE
chore: bump detect-secrets to 1.4.0

### DIFF
--- a/detect-secrets/Dockerfile
+++ b/detect-secrets/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim
 
 
-ARG toolVersion=1.3.0
+ARG toolVersion=1.4.0
 ARG ourVersion=1
 
 LABEL version="$toolVersion-$ourVersion"


### PR DESCRIPTION
tags pushed.

@ovasdi we should totally automate this build and push step.