### PR TITLE
feat: detect-secrets CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Build and check version
           command: |
@@ -36,8 +35,7 @@ jobs:
     resource_class: small
     steps:
     - checkout
-    - setup_remote_docker:
-        docker_layer_caching: true
+    - setup_remote_docker
     - run:
         name: Tag and push
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+jobs:
+  build_detect_secrets:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    resource_class: small
+    environment:
+      PIP_ROOT_USER_ACTION: ignore
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.18
+      - run:
+          name: Build and tag
+          command: |
+            echo 'print the environment'
+            env
+            echo 'print docker images'
+            docker images
+            echo 'enter the detect-secrets directory'
+            cd detect-secrets
+            echo 'list the directory'
+            ls -la
+            echo 'build and tag'
+            ./build
+            docker images
+
+workflows:
+  detect_secrets:
+    jobs:
+      - build_detect_secrets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,73 +1,17 @@
 version: 2.1
-jobs:
-  detect_secrets_build:
-    docker:
-      - image: cimg/base:stable
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-    resource_class: small
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build and check version
-          command: |
-            cd detect-secrets
-            ./build latest
-            TOOL_VERSION=$(cat Dockerfile | grep 'ARG toolVersion' | cut -d '=' -f 2)
-            BUILD_VERSION=$(docker run artsy/detect-secrets:latest detect-secrets --version)
-            if [[ $BUILD_VERSION == $TOOL_VERSION ]]; then
-              echo "detect-secrets build matches tool version: $BUILD_VERSION"
-            else
-              echo "build version does not match tool version"
-              echo build version: $BUILD_VERSION
-              echo tool version: $TOOL_VERSION
-              exit 1
-            fi
 
-  detect_secrets_push:
-    docker:
-      - image: cimg/base:stable
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_PASSWORD
-    resource_class: small
-    steps:
-    - checkout
-    - setup_remote_docker
-    - run:
-        name: Tag and push
-        command: |
-          cd detect-secrets
-          export TAG=$(date +%Y%m%d).$(echo $CIRCLE_BUILD_NUM)
-          docker tag artsy/detect-secrets:latest artsy/detect-secrets:$TAG
-          docker tag artsy/detect-secrets:latest artsy/detect-secrets:ci
-          ./push $TAG
-          ./push ci
-          ./push latest
+# enable CircleCI dynamic configuration
+setup: true
 
-only_detect_secrets: &only_detect_secrets
-  filters:
-    branches:
-      only:
-        - /.*detect-secrets.*/
+orbs:
+  path-filtering: circleci/path-filtering@0.1.3
 
 workflows:
-  detect-secrets:
+  always-run:
     jobs:
-      - detect_secrets_build:
-          <<: *only_detect_secrets
-          context:
-            - docker
-      - hold:
-          <<: *only_detect_secrets
-          type: approval
-          requires:
-            - detect_secrets_build
-      - detect_secrets_push:
-          <<: *only_detect_secrets
-          context:
-            - docker
-          requires:
-            - hold
+      - path-filtering/filter:
+          name: detect-secrets
+          mapping: |
+            detect-secrets/.* detect-secrets true
+          base-revision: main
+          config-path: detect-secrets/continue_config.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,71 @@
 version: 2.1
 jobs:
-  build_detect_secrets:
+  detect_secrets_build:
     docker:
       - image: cimg/base:stable
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
     resource_class: small
-    environment:
-      PIP_ROOT_USER_ACTION: ignore
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.18
+          docker_layer_caching: true
       - run:
-          name: Build and tag
+          name: Build and check version
           command: |
-            echo 'print the environment'
-            env
-            echo 'print docker images'
-            docker images
-            echo 'enter the detect-secrets directory'
             cd detect-secrets
-            echo 'list the directory'
-            ls -la
-            echo 'build and tag'
-            ./build
-            docker images
+            ./build latest
+            TOOL_VERSION=$(cat Dockerfile | grep 'ARG toolVersion' | cut -d '=' -f 2)
+            BUILD_VERSION=$(docker run artsy/detect-secrets:latest detect-secrets --version)
+            if [[ $BUILD_VERSION == $TOOL_VERSION ]]; then
+              echo "detect-secrets build matches tool version: $BUILD_VERSION"
+            else
+              echo "build version does not match tool version"
+              echo build version: $BUILD_VERSION
+              echo tool version: $TOOL_VERSION
+              exit 1
+            fi
+
+  detect_secrets_push:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    resource_class: small
+    steps:
+    - checkout
+    - setup_remote_docker:
+        docker_layer_caching: true
+    - run:
+        name: Tag and push
+        command: |
+          cd detect-secrets
+          export TAG=$(date +%Y%m%d).$(echo $CIRCLE_BUILD_NUM)
+          docker tag artsy/detect-secrets:latest artsy/detect-secrets:$TAG
+          docker tag artsy/detect-secrets:latest artsy/detect-secrets:ci
+          ./push $TAG
+          ./push ci
+          ./push latest
+
+only_detect_secrets: &only_detect_secrets
+  filters:
+    branches:
+      only:
+        - /.*detect-secrets.*/
 
 workflows:
-  detect_secrets:
+  detect-secrets:
     jobs:
-      - build_detect_secrets
+      - detect_secrets_build:
+          <<: *only_detect_secrets
+      - hold:
+          <<: *only_detect_secrets
+          type: approval
+          requires:
+            - detect_secrets_build
+      - detect_secrets_push:
+          <<: *only_detect_secrets
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ workflows:
     jobs:
       - detect_secrets_build:
           <<: *only_detect_secrets
+          context:
+            - docker
       - hold:
           <<: *only_detect_secrets
           type: approval
@@ -67,5 +69,7 @@ workflows:
             - detect_secrets_build
       - detect_secrets_push:
           <<: *only_detect_secrets
+          context:
+            - docker
           requires:
             - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,6 @@ workflows:
       - path-filtering/filter:
           name: detect-secrets
           mapping: |
-            detect-secrets/.* detect-secrets true
+            detect-secrets/Dockerfile detect-secrets true
           base-revision: main
           config-path: detect-secrets/continue_config.yml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Public Docker images for Artsy applications
 
+> CI has been configured to use [dynamic configuration](https://circleci.com/docs/using-dynamic-configuration/) and [circleci/path-filtering orb](https://circleci.com/developer/orbs/orb/circleci/path-filtering).
+
 ## Adding an image to Docker Hub
 
 Adding an image to Docker Hub is a two-step process, first you build a new tag

--- a/detect-secrets/Dockerfile
+++ b/detect-secrets/Dockerfile
@@ -7,6 +7,7 @@ ARG artsyVersion=1
 LABEL version="$toolVersion-$artsyVersion"
 LABEL org.opencontainers.image.authors="Artsy"
 
+ENV PIP_ROOT_USER_ACTION=ignore
 
 RUN apt-get update && apt-get install -y \
   --no-install-recommends \

--- a/detect-secrets/Dockerfile
+++ b/detect-secrets/Dockerfile
@@ -2,9 +2,9 @@ FROM --platform=linux/amd64 python:3.10-slim
 
 
 ARG toolVersion=1.4.0
-ARG ourVersion=1
+ARG artsyVersion=1
 
-LABEL version="$toolVersion-$ourVersion"
+LABEL version="$toolVersion-$artsyVersion"
 LABEL org.opencontainers.image.authors="Artsy"
 
 

--- a/detect-secrets/README.md
+++ b/detect-secrets/README.md
@@ -1,0 +1,48 @@
+
+# Detect Secrets Artsy Docker Image
+
+A custom docker image of [Yelp/detect-secrets](https://github.com/Yelp/detect-secrets)
+<sup>*Used across select Artsy CI pipelines*</sup>
+
+Dockerhub repo: [artsy/detect-secrets](https://hub.docker.com/r/artsy/detect-secrets)
+
+## Upgrade and Release
+
+To build and release a new version using CI:
+
+1. Cut a new branch and include '`detect-secrets`' in the branch name (_required_ to trigger the workflow run)
+1. Modify the `Dockerfile` and change the version of `toolVersion` _ARG_ to the desired `detect-secrets` version (_likely the latest [released](https://github.com/Yelp/detect-secrets/releases) version_)
+1. Push the change and open a PR
+1. _Optional_: verify the build version
+    <details>
+      <summary>Explain</summary>
+
+      Upon success _detect_secrets_build_ job will print out the built tool version
+
+      ![version check](https://drive.google.com/uc?id=1kmPPgW6emB3xg7TUbyubTC-Tmvopb1aM)
+
+    </details>
+1. Once the PR is approved, approve the _workflow hold_ to release the new version
+    <details>
+      <summary>Explain</summary>
+
+    ![approve hold](https://drive.google.com/uc?id=1BNMYP71hWlrUfXd3vZ6nuuFxalkEsN2U)
+
+    - When the change is pushed to github, a new image is built and the workflow is put on _hold_. This is done to allow for a _more_ controlled release and to prevent the image from getting pushed upstream until the PR is _reviewed and approved_
+    - Once the _workflow hold_ is approved the new image is pushed to dockerhub (including all associated tags)
+      - Any project using this image (`ci` tag specifically) will start using the new version
+
+    </details>
+1. Merge the PR (once all steps :green_circle:)
+
+## Build
+
+When necessary to build manually (_outside CI_) use the `build` script
+
+`./build [version]`
+
+## Push
+
+To push image to dockerhub use the `push` script
+
+`./push [version]`

--- a/detect-secrets/README.md
+++ b/detect-secrets/README.md
@@ -6,34 +6,26 @@ A custom docker image of [Yelp/detect-secrets](https://github.com/Yelp/detect-se
 
 Dockerhub repo: [artsy/detect-secrets](https://hub.docker.com/r/artsy/detect-secrets)
 
-## Upgrade and Release
+## Build and Release using CI
 
-To build and release a new version using CI:
+To build and release a new version:
 
-1. Cut a new branch and include '`detect-secrets`' in the branch name (_required_ to trigger the workflow run)
 1. Modify the `Dockerfile` and change the version of `toolVersion` _ARG_ to the desired `detect-secrets` version (_likely the latest [released](https://github.com/Yelp/detect-secrets/releases) version_)
 1. Push the change and open a PR
 1. _Optional_: verify the build version
     <details>
       <summary>Explain</summary>
 
-      Upon success _detect_secrets_build_ job will print out the built tool version
+      Upon success _detect_secrets_build_ job will print out the tool version
 
-      ![version check](https://drive.google.com/uc?id=1kmPPgW6emB3xg7TUbyubTC-Tmvopb1aM)
-
-    </details>
-1. Once the PR is approved, approve the _workflow hold_ to release the new version
-    <details>
-      <summary>Explain</summary>
-
-    ![approve hold](https://drive.google.com/uc?id=1BNMYP71hWlrUfXd3vZ6nuuFxalkEsN2U)
-
-    - When the change is pushed to github, a new image is built and the workflow is put on _hold_. This is done to allow for a _more_ controlled release and to prevent the image from getting pushed upstream until the PR is _reviewed and approved_
-    - Once the _workflow hold_ is approved the new image is pushed to dockerhub (including all associated tags)
-      - Any project using this image (`ci` tag specifically) will start using the new version
+      ```
+      Successfully built b83d1aaea7ee
+      Successfully tagged artsy/detect-secrets:20230113.174
+      detect-secrets build matches specified tool version: 1.4.0
+      ```
 
     </details>
-1. Merge the PR (once all steps :green_circle:)
+1. Merging the PR to `main` will trigger the `detect-secrets-release` _workflow_ and the new image, tags will be pushed to dockerhub
 
 ## Build
 

--- a/detect-secrets/build
+++ b/detect-secrets/build
@@ -14,9 +14,7 @@ set -euo pipefail
 
 ALLOWED_ARGS="[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+|^[0-9]{8}.[0-9]{1,}$|latest|ci"
 
-TAG=
-
-# If more than one argument is passed, exit
+# If more than one parameter is passed, exit
 if [[ $# -gt 1 ]]; then
   echo "Usage: ./build"
   echo "or"
@@ -24,20 +22,17 @@ if [[ $# -gt 1 ]]; then
   exit 1
 fi
 
-# If an argument is passed, set the TAG to the argument
+# Check if a parameter is passed
 if [[ $# -eq 1 ]]; then
-  # If the argument is not of the allowed format, exit
+  # When a parameter is not of the allowed format, print a message and exit
   if [[ ! $1 =~ $ALLOWED_ARGS ]]; then
-    echo "Invalid argument: $1"
-    echo "Allowed argument format(s): 1.2.3-1, 20230101.1, latest, ci"
+    echo "Invalid parameter: $1"
+    echo "Allowed parameter format(s): 1.2.3-1, 20230101.1, latest, ci"
     exit 1
   fi
-  TAG=$1
 fi
 
-# If no arguments are passed, set the TAG to: current-date.seconds (20230101.123)
-if [[ $# -eq 0 ]]; then
-  TAG=$(date +%Y%m%d).$(date +%s)
-fi
+# Set TAG to passed parameter otherwise default to current-date.seconds (20230101.123)
+TAG=${1:-$(date +%Y%m%d).$(date +%s)}
 
 docker build -t artsy/detect-secrets:$TAG .

--- a/detect-secrets/build
+++ b/detect-secrets/build
@@ -1,11 +1,56 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-
 # Usage:
+# ./build
+# or
 # ./build 1.2.0-1
 # or
 # ./build latest
 
+ALLOWED_ARGS="[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+|latest|ci"
 
-docker build -t artsy/detect-secrets:$1 .
+TOOL_VERSION=
+ARTSY_VERSION=
+TAG=
+
+# If more than one argument is passed, exit
+if [[ $# -gt 1 ]]; then
+  echo "Usage: ./build"
+  echo "or"
+  echo "Usage: ./build [version]"
+  exit 1
+fi
+
+# If an argument is passed, set the TAG to the argument
+if [[ $# -eq 1 ]]; then
+  # If the argument is not of the form 1.2.3-1, latest, or ci, exit
+  if [[ ! $1 =~ $ALLOWED_ARGS ]]; then
+    echo "Invalid argument: $1"
+    echo "Valid argument formats: 1.2.3-1, latest, ci"
+    exit 1
+  fi
+  TAG=$1
+fi
+
+# If no arguments are passed, build the version specified in the Dockerfile
+if [[ $# -eq 0 ]]; then
+  # extract the tool version from the Dockerfile ARG (e.g. 1.2.0)
+  TOOL_VERSION=$(cat Dockerfile | grep 'ARG toolVersion' | cut -d '=' -f 2)
+  # extract the artsy version from the Dockerfile ARG (e.g. 1)
+  ARTSY_VERSION=$(cat Dockerfile | grep 'ARG artsyVersion' | cut -d '=' -f 2)
+  TAG=$TOOL_VERSION-$ARTSY_VERSION
+fi
+
+echo "Building artsy/detect-secrets:$TAG"
+docker build -t artsy/detect-secrets:$TAG .
+
+if [[ $TAG != latest ]]; then
+  echo "Tag artsy/detect-secrets:latest"
+  docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:latest
+fi
+
+if [[ $TAG != ci ]]; then
+  echo "Tag artsy/detect-secrets:ci"
+  docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:ci
+fi

--- a/detect-secrets/build
+++ b/detect-secrets/build
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 # Usage:
 # ./build
 # or
 # ./build 1.2.0-1
 # or
+# ./build 20230101.1
+# or
 # ./build latest
+# or
+# ./build ci
 
-ALLOWED_ARGS="[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+|latest|ci"
+ALLOWED_ARGS="[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+|^[0-9]{8}.[0-9]{1,}$|latest|ci"
 
-TOOL_VERSION=
-ARTSY_VERSION=
 TAG=
 
 # If more than one argument is passed, exit
@@ -24,33 +26,18 @@ fi
 
 # If an argument is passed, set the TAG to the argument
 if [[ $# -eq 1 ]]; then
-  # If the argument is not of the form 1.2.3-1, latest, or ci, exit
+  # If the argument is not of the allowed format, exit
   if [[ ! $1 =~ $ALLOWED_ARGS ]]; then
     echo "Invalid argument: $1"
-    echo "Valid argument formats: 1.2.3-1, latest, ci"
+    echo "Allowed argument format(s): 1.2.3-1, 20230101.1, latest, ci"
     exit 1
   fi
   TAG=$1
 fi
 
-# If no arguments are passed, build the version specified in the Dockerfile
+# If no arguments are passed, set the TAG to: current-date.seconds (20230101.123)
 if [[ $# -eq 0 ]]; then
-  # extract the tool version from the Dockerfile ARG (e.g. 1.2.0)
-  TOOL_VERSION=$(cat Dockerfile | grep 'ARG toolVersion' | cut -d '=' -f 2)
-  # extract the artsy version from the Dockerfile ARG (e.g. 1)
-  ARTSY_VERSION=$(cat Dockerfile | grep 'ARG artsyVersion' | cut -d '=' -f 2)
-  TAG=$TOOL_VERSION-$ARTSY_VERSION
+  TAG=$(date +%Y%m%d).$(date +%s)
 fi
 
-echo "Building artsy/detect-secrets:$TAG"
 docker build -t artsy/detect-secrets:$TAG .
-
-if [[ $TAG != latest ]]; then
-  echo "Tag artsy/detect-secrets:latest"
-  docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:latest
-fi
-
-if [[ $TAG != ci ]]; then
-  echo "Tag artsy/detect-secrets:ci"
-  docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:ci
-fi

--- a/detect-secrets/continue_config.yml
+++ b/detect-secrets/continue_config.yml
@@ -1,0 +1,84 @@
+version: 2.1
+
+parameters:
+  detect-secrets:
+    type: boolean
+    default: false
+
+jobs:
+  detect_secrets_build:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    resource_class: small
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build and validate version
+          command: |
+            cd detect-secrets
+            export TAG=$(date +%Y%m%d).$(echo $CIRCLE_BUILD_NUM)
+            ./build $TAG
+            TOOL_VERSION=$(cat Dockerfile | grep 'ARG toolVersion' | cut -d '=' -f 2)
+            BUILD_VERSION=$(docker run artsy/detect-secrets:$TAG detect-secrets --version)
+            if [[ $BUILD_VERSION == $TOOL_VERSION ]]; then
+              echo "detect-secrets build matches specified tool version: $BUILD_VERSION"
+            else
+              echo "build version does not match specified tool version"
+              echo build version: $BUILD_VERSION
+              echo tool version: $TOOL_VERSION
+              exit 1
+            fi
+
+  detect_secrets_build_tag_push:
+    docker:
+      - image: cimg/base:stable
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    resource_class: small
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: Build, tag and push
+        command: |
+          cd detect-secrets
+          export TAG=$(date +%Y%m%d).$(echo $CIRCLE_BUILD_NUM)
+          ./build $TAG
+          docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:latest
+          docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:ci
+          ./push $TAG
+          ./push ci
+          ./push latest
+
+only_main: &only_main
+  filters:
+    branches:
+      only:
+        - main
+
+not_main: &not_main
+  filters:
+    branches:
+      ignore:
+        - main
+
+workflows:
+  detect-secrets-build:
+    when: << pipeline.parameters.detect-secrets >>
+    jobs:
+      - detect_secrets_build:
+          <<: *not_main
+          context:
+            - docker
+  detect-secrets-release:
+    when: << pipeline.parameters.detect-secrets >>
+    jobs:
+      - detect_secrets_build_tag_push:
+          <<: *only_main
+          context:
+            - docker

--- a/detect-secrets/continue_config.yml
+++ b/detect-secrets/continue_config.yml
@@ -51,6 +51,7 @@ jobs:
           ./build $TAG
           docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:latest
           docker tag artsy/detect-secrets:$TAG artsy/detect-secrets:ci
+          echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           ./push $TAG
           ./push ci
           ./push latest

--- a/detect-secrets/push
+++ b/detect-secrets/push
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-set -euxo pipefail
-
+set -euo pipefail
 
 # Usage:
 # ./push 1.2.0-1
 # or
 # ./push latest
 
+TAG=
 
-docker push artsy/detect-secrets:$1
+# if argument is passed, set the TAG to the argument
+if [[ $# -eq 1 ]]; then
+  TAG=$1
+else
+  echo "Usage: ./push [version]"
+  exit 1
+fi
+
+docker push artsy/detect-secrets:$TAG


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4643

This introduces CI pipeline for building and releasing new versions of Artsy `detect-secrets` docker image.

~See the [Upgrade and Release](https://github.com/artsy/docker-images/blob/1138db4eba4ec638c917cd2352f4720500a338c4/detect-secrets/README.md#upgrade-and-release) section for how the process is setup.~

~As described the release trigger is two-fold:~
~- '_detect-secrets_' must be included in the branch name for the workflow to run~
~- a '_hold_' mechanism is in place to allow for more controlled release: in case a follow-up change needs to be made or to wait for a PR approval etc...~

---

This PR has been heavily adjusted following feedback. See [this comment](https://github.com/artsy/docker-images/pull/96#issuecomment-1382507994).