### PR TITLE
Add setup for ruby 3 and node 18

### DIFF
--- a/ruby/3.0.2-node-18-yarn/Dockerfile
+++ b/ruby/3.0.2-node-18-yarn/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:3.0.2-alpine3.13
+
+# Install Node + Yarn
+ENV NODE_VERSION 18.0.0
+ENV YARN_VERSION 1.22.5
+
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node \
+  && apk add --no-cache libstdc++ \
+  && apk add --no-cache --virtual .build-deps curl \
+  && curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && rm -f "node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && apk del .build-deps
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn


### PR DESCRIPTION
This is required for updating Volt to Node 18: https://github.com/artsy/volt/pull/6694

We need an image that contains Ruby 3 + Node 18