### PR TITLE
chore: update README to include instructions to build in amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Adding an image to Docker Hub is a two-step process, first you build a new tag
 and then you push it up, here's an example:
 
 ```
-$ docker build -t artsy/ruby:2.5.3-node-chrome ruby/2.5.3-node-chrome/
+$ docker build -t artsy/ruby:2.5.3-node-chrome ruby/2.5.3-node-chrome/ --platform linux/amd64
 $ docker push artsy/ruby:2.5.3-node-chrome
 ```
 


### PR DESCRIPTION
Building on apple silicon will result in the wrong architecture, as caught by @jpotts244 (see below screenshot, OS/ARCH is set to linux/amd64/v8).

![Screen Shot 2023-04-12 at 4 28 21 PM](https://user-images.githubusercontent.com/1389948/231581642-6756725e-9af3-473a-9ba2-da93e3be5615.png)

Using the `--platform linux/amd64` parameter ensures we're only building images on linux/amd64