### PR TITLE
fix: out of date scala image

### DIFF
--- a/scala/Dockerfile
+++ b/scala/Dockerfile
@@ -1,30 +1,22 @@
-FROM artsy/hokusai
+FROM amazoncorretto:8
 
 ENV SCALA_VERSION=2.12.7 \
-    SBT_VERSION=1.2.6 \
     DOCKERIZE_VERSION=v0.6.1
 
-RUN apt-get update -qq && \
-    apt-get install -y --no-install-recommends wget curl tar gzip postgresql-client awscli jq\
-                                               openjdk-8-jdk ca-certificates-java && \
-    cd "/tmp" && \
-    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
-    curl -q -L -O www.scala-lang.org/files/archive/scala-$SCALA_VERSION.deb && \
-    dpkg -i scala-$SCALA_VERSION.deb && \
-    curl -q -L -O https://bintray.com/artifact/download/sbt/debian/sbt-$SBT_VERSION.deb && \
-    dpkg -i sbt-$SBT_VERSION.deb && \
-    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    apt-get install -y nodejs && \
-    ls /usr/bin/p* && \
-    pip2 install hokusai && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -L https://www.scala-sbt.org/sbt-rpm.repo | tee /etc/yum.repos.d/scala-sbt-rpm.repo
 
-# Trigger compiler-interface compilation
-RUN  cd "/tmp" && \
-  mkdir -p project src/main/scala && \
-  echo "sbt.version = ${SBT_VERSION}" > project/build.properties && \
-  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
-  touch src/main/scala/scratch.scala && \
-  sbt compile && \
-  rm -rf *
+RUN yum install -y wget tar gzip awscli jq sbt
+
+RUN cd /tmp && \
+    wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN cd /tmp && \
+    curl -q -L -O https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz && \
+    tar -zxf scala-${SCALA_VERSION}.tgz -C /usr/local
+
+ENV PATH=/usr/local/scala-$SCALA_VERSION/bin:$PATH
+
+WORKDIR /home
+
+RUN scala -version


### PR DESCRIPTION
Cinder CI started [failing](https://app.circleci.com/pipelines/github/artsy/cinder) on out of date debian repository references in our `artsy/scala` Docker image (`latest` tag). The image was based on `artsy/hokusai` but hadn't been built in 5 years. The `hokusai` base image is now alpine (no longer Debian), so @amonkhouse & I tried to fix up the scala image to work with that, but we encountered a number of issues with the jdk libs required. 

It was much easier to switch to `amazoncorretto` which is the Amazon Linux java image used by Causality when running scala. Note that Causality defines its own `scala:2.12` tagged image [here](https://github.com/artsy/docker-images/blob/main/scala/scala-2.12/Dockerfile). It does not build off this image. We now run it on jdk8 and simply install the latest version of `sbt` (1.8.2). This then reads the old sbt version from the Cinder sbt project file and is able to switch to running on 0.13 at runtime.

CI now works as tested [here](https://github.com/artsy/cinder/pull/413). We also have a much simpler image and less circle boilerplate code.