### PR TITLE
chore: bump alpine to 3.14 for ruby:3.0.2-node-14-yarn

### DIFF
--- a/ruby/3.0.2-node-14-yarn/Dockerfile
+++ b/ruby/3.0.2-node-14-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.2-alpine3.13
+FROM ruby:3.0.2-alpine3.14
 
 # Install Node + Yarn
 ENV NODE_VERSION 14.17.4


### PR DESCRIPTION
This bumps alpine version to 3.14 (from 3.13).

The primary motivation is to allow us to use a more recent version of python, 3.9+, in [horizon](https://github.com/artsy/horizon) so that latest version of hokusai can be installed which depends on python >=3.9. Highest version of python available in [alpine3.13 is 3.8.15](https://pkgs.alpinelinux.org/packages?name=python3&branch=v3.13&repo=&arch=&maintainer=).

This image is also used in [gravity](https://github.com/artsy/gravity/blob/main/Dockerfile#L2). Local build succeded using this new base.

Related [slack thread](https://artsy.slack.com/archives/CA8SANW3W/p1691420429917559).