### PR TITLE
chore: multi-arch Elasticsearch v6.8.23 image

### DIFF
--- a/elasticsearch/6.8.23/README.md
+++ b/elasticsearch/6.8.23/README.md
@@ -2,8 +2,16 @@
 
 Artsy custom Elasticsearch image is available for the following linux architectures: `amd64`, `arm64`
 
+Download:
+
 ```
 docker pull artsy/elasticsearch:6.8.23
+```
+
+Run:
+
+```
+docker run --rm -p 9200:9200 -p 9300:9300 -e http.cors.enabled=true -e http.cors.allow-origin='*' -e ES_JAVA_OPTS='-Xms512m -Xmx512m' artsy/elasticsearch:6.8.23
 ```
 
 ## Custom Elasticsearch v6.8.23 image(s)

--- a/elasticsearch/6.8.23/README.md
+++ b/elasticsearch/6.8.23/README.md
@@ -1,0 +1,47 @@
+## Elasticsearch v6.8.23
+
+Artsy custom Elasticsearch image is available for the following linux architectures: `amd64`, `arm64`
+
+```
+docker pull artsy/elasticsearch:6.8.23
+```
+
+## Custom Elasticsearch v6.8.23 image(s)
+
+The [official Elasticsearch docker repository](https://hub.docker.com/_/elasticsearch/tags?page=1&name=6.8.23) does not provide a `v6.8.23` image for `arm64` architecture. Running an `amd64` Elasticsearch `v6.8.23` image on Apple chip is not without issues and performance implications. To work around this absence and in order to make multi-arch images available the following _custom_ images are made available: [v6.8.23-amd64](https://hub.docker.com/r/artsy/elasticsearch/tags?page=1&name=6.8.23-amd64), [v6.8.23-arm64](https://hub.docker.com/r/artsy/elasticsearch/tags?page=1&name=6.8.23-arm64)
+
+Included below are commands for building and pushing images:
+
+> docker login is _required_ to access artsy repository
+
+> add `--platform linux/amd64` option to the `docker build` command when building `amd64` image on `arm64` hardware
+```
+# amd64 image build and push
+cd amd64
+docker build -t artsy/elasticsearch:6.8.23-amd64 .
+docker push artsy/elasticsearch:6.8.23-amd64
+
+# arm64 image build and push
+cd arm64
+docker build -t artsy/elasticsearch:6.8.23-arm64 .
+docker push artsy/elasticsearch:6.8.23-arm64
+```
+
+## Multi-arch Elasticsearch image via docker manifest
+
+> A manifest list is a list of image layers that is created by specifying one or more (ideally more than one) image names. It can then be used in the same way as an image name in `docker pull` and `docker run` commands
+
+<sup>More details on docker manifest available in [docs](https://docs.docker.com/engine/reference/commandline/manifest/)</sup>
+
+To create a manifest and make it available the underlying [images](#custom-elasticsearch-v6823-images) must be made available first. Once the images are available a manifest can be created like:
+
+```
+# create manifest
+docker manifest create artsy/elasticsearch:6.8.23 artsy/elasticsearch:6.8.23-amd64 artsy/elasticsearch:6.8.23-arm64
+
+# inspect manifest
+docker manifest inspect --verbose artsy/elasticsearch:6.8.23
+
+# push manifest
+docker manifest push artsy/elasticsearch:6.8.23
+```

--- a/elasticsearch/6.8.23/README.md
+++ b/elasticsearch/6.8.23/README.md
@@ -20,7 +20,7 @@ The [official Elasticsearch docker repository](https://hub.docker.com/_/elastics
 
 Included below are commands for building and pushing images:
 
-> docker login is _required_ to access artsy repository
+> `docker login` is _required_ to access the artsy repository. credentials are located under "Docker" entry in 1password
 
 > add `--platform linux/amd64` option to the `docker build` command when building `amd64` image on `arm64` hardware
 ```

--- a/elasticsearch/6.8.23/amd64/Dockerfile
+++ b/elasticsearch/6.8.23/amd64/Dockerfile
@@ -1,0 +1,15 @@
+# custom amd64 elasticsearch v6.8.23 image
+FROM elasticsearch:6.8.23
+
+RUN useradd -m elasticuser
+
+COPY elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+
+WORKDIR /usr/share/elasticsearch
+
+RUN chown -R elasticuser: .
+
+USER elasticuser
+
+EXPOSE 9200 9300
+CMD ["elasticsearch"]

--- a/elasticsearch/6.8.23/amd64/elasticsearch.yml
+++ b/elasticsearch/6.8.23/amd64/elasticsearch.yml
@@ -1,0 +1,14 @@
+cluster.name: "docker-cluster"
+
+discovery.type: "single-node"
+xpack.security.enabled: false
+bootstrap.memory_lock: true
+
+# When running on arm64 hardware, consider enabling this option if you start seeing
+# system call filter failures preventing Elasticsearch startup.
+# https://www.elastic.co/guide/en/elasticsearch/reference/6.8/_system_call_filter_check.html
+#
+# bootstrap.system_call_filter: false
+
+http.host: 0.0.0.0
+transport.host: 0.0.0.0

--- a/elasticsearch/6.8.23/arm64/Dockerfile
+++ b/elasticsearch/6.8.23/arm64/Dockerfile
@@ -1,0 +1,27 @@
+# custom arm64 elasticsearch v6.8.23 image
+# adopted from https://stackoverflow.com/questions/68877644/how-to-run-elasticsearch-6-on-an-apple-silicon-mac/70713284#70713284
+FROM arm64v8/openjdk:8-jdk-slim-bullseye
+
+WORKDIR /tmp
+
+RUN useradd -m elasticuser
+
+RUN apt update && apt install -y curl
+
+RUN curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.8.23.tar.gz \
+    && tar -xvf elasticsearch-6.8.23.tar.gz \
+    && mv elasticsearch-6.8.23 /usr/share/elasticsearch \
+    && rm -rf elasticsearch-6.8.23.tar.gz
+
+ADD elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
+
+ENV PATH="/usr/share/elasticsearch/bin:${PATH}"
+
+WORKDIR /usr/share/elasticsearch
+
+RUN chown -R elasticuser: .
+
+USER elasticuser
+
+EXPOSE 9200 9300
+CMD ["elasticsearch"]

--- a/elasticsearch/6.8.23/arm64/elasticsearch.yml
+++ b/elasticsearch/6.8.23/arm64/elasticsearch.yml
@@ -1,0 +1,9 @@
+cluster.name: "docker-cluster"
+
+discovery.type: "single-node"
+xpack.security.enabled: false
+xpack.ml.enabled: false
+bootstrap.memory_lock: true
+
+http.host: 0.0.0.0
+transport.host: 0.0.0.0


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-393

This supports the [local development](https://artsyproduct.atlassian.net/browse/PHIRE-330) effort.

Immediately after starting work on the gravity local dev stack, it became evident that running the `amd64` architecture Elasticsearch `v6.8.23` image is problematic. The service would not start up consistently, there were errors in the logs requiring additional Elasticsearch configuration to be enabled as well as obvious performance issues that made the experience worse.

> Official Elasticsearch `arm64` support starts with [v7.8.0](https://www.elastic.co/blog/elasticsearch-on-arm).

This PR introduces _two_ custom Elasticsearch images, one for `amd64` and one for `arm64` so that a docker manifest can be created and made available for local development use cases.

The following Elasticsearch configuration options are added:

- [`cluster.name: "docker-cluster"`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cluster.name.html#cluster.name)
- [`discovery.type: "single-node"`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/bootstrap-checks.html#single-node-discovery)
- [`xpack.security.enabled: false`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/security-settings.html#general-security-settings)
- [`bootstrap.memory_lock: true`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/_memory_lock_check.html#_memory_lock_check)
- [`xpack.ml.enabled: false`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/ml-settings.html#general-ml-settings) (`arm64` only)
- [`http.host: 0.0.0.0`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-network.html#common-network-settings)
- [`transport.host: 0.0.0.0`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-transport.html#_transport_settings)

For more details see `elasticsearch/6.8.23/README.md`.
