### PR TITLE
chore: ruby 3.1.4

### DIFF
--- a/ruby/3.1.4-node-18-yarn/Dockerfile
+++ b/ruby/3.1.4-node-18-yarn/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:3.1.4-alpine3.18
+
+# Install Node + Yarn
+ENV NODE_VERSION 18.15.0
+ENV YARN_VERSION 1.22.5
+
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node \
+  && apk add --no-cache libstdc++ \
+  && apk add --no-cache --virtual .build-deps curl \
+  && curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && rm -f "node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && apk del .build-deps
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn


### PR DESCRIPTION
Adding 3.1.4 image
[Uploaded to docker hub](https://hub.docker.com/layers/artsy/ruby/3.1.4-node-18-yarn/images/sha256-63811e95d916f2c972314fa2413e8279fc19459b4f6452882c691ef3d53e5a07?context=explore)
[Working in Pulse](https://app.circleci.com/pipelines/github/artsy/pulse?branch=leamotta%2Fruby-3.1)