### PR TITLE
chore: bump detect-secrets version to 1.5.0

### DIFF
--- a/detect-secrets/Dockerfile
+++ b/detect-secrets/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 python:3.10-slim
 
 
-ARG toolVersion=1.4.0
+ARG toolVersion=1.5.0
 ARG artsyVersion=1
 
 LABEL version="$toolVersion-$artsyVersion"


### PR DESCRIPTION
detect-secrets `v1.5.0` has been [released](https://github.com/Yelp/detect-secrets/releases/tag/v1.5.0) and just landed in [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/master/Formula/d/detect-secrets.rb). This bumps the version so CI wont be [blowing up](https://app.circleci.com/pipelines/github/artsy/gravity/28469/workflows/fef6418f-4b4a-48e3-86b6-26f97649fb75/jobs/52826) when users push version change of the `.secrets.baseline`.