### PR TITLE
chore: add load-secrets-and-run.sh to mongo and pg data sync images

### DIFF
--- a/mongo-data-sync/Dockerfile
+++ b/mongo-data-sync/Dockerfile
@@ -1,10 +1,10 @@
-FROM mongo:4.4
+FROM mongo:6
 
 RUN apt-get update -qq && apt-get install -y awscli dumb-init && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD export-db.sh .
 ADD import-db.sh .
-ADD load-secrets-and-run ./load-secrets-and-run.sh
+ADD load-secrets-and-run.sh ./load-secrets-and-run.sh
 
 ENTRYPOINT [ "dumb-init", "./load-secrets-and-run.sh" ]
 CMD ["sh", "./export-db.sh", "latest"]

--- a/mongo-data-sync/Dockerfile
+++ b/mongo-data-sync/Dockerfile
@@ -1,8 +1,10 @@
 FROM mongo:4.4
 
-RUN apt-get update -qq && apt-get install -y awscli && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -qq && apt-get install -y awscli dumb-init && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD export-db.sh .
 ADD import-db.sh .
+ADD load-secrets-and-run ./load-secrets-and-run.sh
 
+ENTRYPOINT [ "dumb-init", "./load-secrets-and-run.sh" ]
 CMD ["sh", "./export-db.sh", "latest"]

--- a/mongo-data-sync/load-secrets-and-run.sh
+++ b/mongo-data-sync/load-secrets-and-run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+CMD="$@"
+
+if [ ! -z "$SECRETS_FILE" ]
+then
+  echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+  source "$SECRETS_FILE"
+fi
+
+echo "Running command: $CMD"
+$CMD

--- a/mongo-data-sync/load-secrets-and-run.sh
+++ b/mongo-data-sync/load-secrets-and-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CMD="$@"
 

--- a/pg-data-sync/Dockerfile
+++ b/pg-data-sync/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:12
 
-RUN apt-get update -qq && apt-get install -y curl unzip mandoc && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update -qq && apt-get install -y curl unzip mandoc dumb-init && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
@@ -9,5 +9,7 @@ RUN rm -rf awscliv2.zip aws
 
 ADD export-db.sh .
 ADD import-db.sh .
+ADD load-secrets-and-run.sh .
 
+ENTRYPOINT [ "dumb-init", "./load-secrets-and-run.sh" ]
 CMD ["sh", "./export-db.sh", "latest"]

--- a/pg-data-sync/load-secrets-and-run.sh
+++ b/pg-data-sync/load-secrets-and-run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+CMD="$@"
+
+if [ ! -z "$SECRETS_FILE" ]
+then
+  echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+  source "$SECRETS_FILE"
+fi
+
+echo "Running command: $CMD"
+$CMD

--- a/pg-data-sync/load-secrets-and-run.sh
+++ b/pg-data-sync/load-secrets-and-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CMD="$@"
 


### PR DESCRIPTION
This PR adds the `load-secrets-and-run.sh` script to our `mongo-data-sync` and `pg-data-sync` `docker` images. This allows the image to support our `vault` setup and load secrets into their containers without the use of `ConfigMaps` to [store shared scripts](https://github.com/artsy/positron/pull/3165). 

While we could potentially import a shared script from outside each's directory, I opted to keep all parts of the build process located within the respective `Dockerfile` context. 

### Migration

Follow the `README` [instructions](https://artsyproduct.atlassian.net/browse/PHIRE-1419), to rebuild and push the updated image to our docker-hub.


[PHIRE-1419]

[PHIRE-1419]: https://artsyproduct.atlassian.net/browse/PHIRE-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ