### PR TITLE
chore: upgrade pg-data-sync database version

### DIFF
--- a/pg-data-sync/Dockerfile
+++ b/pg-data-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12
+FROM postgres:14.12
 
 RUN apt-get update -qq && apt-get install -y curl unzip mandoc dumb-init && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/pg-data-sync/Makefile
+++ b/pg-data-sync/Makefile
@@ -1,5 +1,5 @@
 project := pg-data-sync
-image_tag ?= 12
+image_tag ?= 14.12
 
 help:
 	@echo 'Commands:'

--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -58,7 +58,7 @@ start_datetime=$(date -u +"%D %T %Z")
 echo "[S3 upload] Starting at $start_datetime"
 
 if [ "$USE_ARCHIVE_TIMESTAMP" = "1" ]; then
-  timestamp=`date +%m-%d-%Y--%l-%M-%S`
+  timestamp=`date +%m-%d-%Y--%H-%M-%S`
   aws s3 cp --no-progress /tmp/archive.pgdump s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
   aws s3 ls s3://artsy-data/$APP_NAME/$ARCHIVE_NAME--$timestamp.pgdump
 else


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-1637

Prepares for rds gravity-production engine version bump

- Upgrade pg (data-sync) image version to match rds server version

Tags already pushed: [ecr](https://us-east-1.console.aws.amazon.com/ecr/repositories/private/585031190124/pg-data-sync?region=us-east-1), [hub](https://hub.docker.com/r/artsy/pg-data-sync/tags)