### PR TITLE
fix: pass all args from position 2 onwards to pg_dump

### DIFF
--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -12,12 +12,14 @@ fi
 
 ARCHIVE_NAME=$1
 
-if test -z "$2"
-then
-  PG_DUMP_ARGS="-O -Fc -v"
+if [ $# -gt 1 ]; then
+  PG_DUMP_ARGS="${@:2}"
 else
-  PG_DUMP_ARGS=$2
+  PG_DUMP_ARGS="-O -Fc -v"
 fi
+
+echo "Using archive name: $ARCHIVE_NAME"
+echo "Running pg_dump with args: $PG_DUMP_ARGS"
 
 if test -z "$DATABASE_URL"
 then


### PR DESCRIPTION
Switching the entrypoint to `load-secrets-and-run.sh` has caused an issue where each word split on whitespace [here](https://github.com/artsy/motion/blob/902fed7e8930670389b5ed544c08a96131327088/dags/gravity/data_sync/pipeline.py#L97-L99) is passed to `export-db.sh` as an individual arg. This means only `-O` has been passed to `pg_dump`, resulting in memory and disk issues. This fixes that issue by:

1. Checking that more than one arg was passed to `export-db.sh`
2. If there was, set `PG_DUMP_ARGS` as all args from the second onwards.

I tested this locally by running the following (taken from @ovasdi ):

```
docker build --platform linux/amd64 -f Dockerfile -t pg-data-sync:test .
docker run -it --platform linux/amd64 pg-data-sync:test ./export-db.sh foo "-O -Fc -v --schema=public --exclude-table-data=account_activities --exclude-table-data=account_locations --exclude-table-data=follow_genes"
```

and verified it worked:

> Running pg_dump with args: -O -Fc -v --schema=public --exclude-table-data=account_activities --exclude-table-data=account_locations --exclude-table-data=follow_genes

I also added some more log lines for future debugging if required.