### PR TITLE
fix: pass all args from position 2 onwards to pg_restore

### DIFF
--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -11,15 +11,13 @@ then
 fi
 
 ARCHIVE_NAME=$1
+echo "Using archive name: $ARCHIVE_NAME"
 
 if [ $# -gt 1 ]; then
   PG_DUMP_ARGS="${@:2}"
 else
   PG_DUMP_ARGS="-O -Fc -v"
 fi
-
-echo "Using archive name: $ARCHIVE_NAME"
-echo "Running pg_dump with args: $PG_DUMP_ARGS"
 
 if test -z "$DATABASE_URL"
 then
@@ -49,6 +47,7 @@ fi
 
 start_datetime=$(date -u +"%D %T %Z")
 echo "[pg_dump] Starting at $start_datetime"
+echo "[pg_dump] Running with args: $PG_DUMP_ARGS"
 
 pg_dump -d $DATABASE_URL -f /tmp/archive.pgdump $PG_DUMP_ARGS
 ls -l /tmp/archive.pgdump

--- a/pg-data-sync/export-db.sh
+++ b/pg-data-sync/export-db.sh
@@ -46,17 +46,17 @@ else
 fi
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[pg_dump] Starting at $start_datetime"
+echo "[pg_dump] Starting at: $start_datetime"
 echo "[pg_dump] Running with args: $PG_DUMP_ARGS"
 
 pg_dump -d $DATABASE_URL -f /tmp/archive.pgdump $PG_DUMP_ARGS
 ls -l /tmp/archive.pgdump
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[pg_dump] Ended at $end_datetime"
+echo "[pg_dump] Ended at: $end_datetime"
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[S3 upload] Starting at $start_datetime"
+echo "[S3 upload] Starting at: $start_datetime"
 
 if [ "$USE_ARCHIVE_TIMESTAMP" = "1" ]; then
   timestamp=`date +%m-%d-%Y--%H-%M-%S`
@@ -68,4 +68,4 @@ else
 fi
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[S3 upload] Ended at $end_datetime"
+echo "[S3 upload] Ended at: $end_datetime"

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -9,15 +9,13 @@ then
 fi
 
 ARCHIVE_NAME=$1
+echo "Using archive name: $ARCHIVE_NAME"
 
 if [ $# -gt 1 ]; then
   PG_RESTORE_ARGS="${@:2}"
 else
   PG_RESTORE_ARGS="--clean --if-exists --no-owner --no-privileges --schema=public -v"
 fi
-
-echo "Using archive name: $ARCHIVE_NAME"
-echo "Running pg_restore with args: $PG_RESTORE_ARGS"
 
 if test -z "$DATABASE_URL"
 then
@@ -57,6 +55,7 @@ echo "[S3 download] Ended at $end_datetime"
 
 start_datetime=$(date -u +"%D %T %Z")
 echo "[pg_restore] Starting at $start_datetime"
+echo "[pg_restore] Running with args: $PG_RESTORE_ARGS"
 
 pg_restore /tmp/archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 PG_EXIT_CODE=$?

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -10,12 +10,14 @@ fi
 
 ARCHIVE_NAME=$1
 
-if test -z "$2"
-then
-  PG_RESTORE_ARGS="--clean --if-exists --no-owner --no-privileges --schema=public -v"
+if [ $# -gt 1 ]; then
+  PG_RESTORE_ARGS="${@:2}"
 else
-  PG_RESTORE_ARGS=$2
+  PG_RESTORE_ARGS="--clean --if-exists --no-owner --no-privileges --schema=public -v"
 fi
+
+echo "Using archive name: $ARCHIVE_NAME"
+echo "Running pg_restore with args: $PG_RESTORE_ARGS"
 
 if test -z "$DATABASE_URL"
 then

--- a/pg-data-sync/import-db.sh
+++ b/pg-data-sync/import-db.sh
@@ -44,29 +44,29 @@ else
 fi
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[S3 download] Starting at $start_datetime"
+echo "[S3 download] Starting at: $start_datetime"
 
 aws s3 ls s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump
 aws s3 cp --no-progress s3://artsy-data/$APP_NAME/$ARCHIVE_NAME.pgdump /tmp/archive.pgdump
 ls -l /tmp/archive.pgdump
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[S3 download] Ended at $end_datetime"
+echo "[S3 download] Ended at: $end_datetime"
 
 start_datetime=$(date -u +"%D %T %Z")
-echo "[pg_restore] Starting at $start_datetime"
+echo "[pg_restore] Starting at: $start_datetime"
 echo "[pg_restore] Running with args: $PG_RESTORE_ARGS"
 
 pg_restore /tmp/archive.pgdump -d $DATABASE_URL $PG_RESTORE_ARGS
 PG_EXIT_CODE=$?
 
 end_datetime=$(date -u +"%D %T %Z")
-echo "[pg_restore] Ended at $end_datetime"
+echo "[pg_restore] Ended at: $end_datetime"
 
 if [ "$SWALLOW_ERRORS_ON_RESTORE" = "1" ]; then
   echo "SWALLOW_ERRORS_ON_RESTORE is 1. Exiting script with return code 0."
   exit 0
 else
-  echo "Exiting script with pg_restore return code of $PG_EXIT_CODE"
+  echo "Exiting script with pg_restore return code of: $PG_EXIT_CODE"
   exit $PG_EXIT_CODE
 fi


### PR DESCRIPTION
Follow-up to https://github.com/artsy/docker-images/pull/115

The weekly sync does not _currently_ pass additional args when running the [import](https://github.com/artsy/motion/blob/902fed7e8930670389b5ed544c08a96131327088/dags/gravity/data_sync/pipeline.py#L114-L116) but this could change in the future and then `pg_restore` would fail similarly as we saw last weekend. This copies the fix from related PR to the `import-db.sh` making is safe to pass additional arguments.

```sh
docker run -it ... pg-data-sync:test ./import-db.sh foo "--clean --if-exists --no-owner --no-privileges --schema=public -v"
...
Running command: ./import-db.sh foo --clean --if-exists --no-owner --no-privileges --schema=public -v
Using archive name: foo
...
[pg_restore] Running with args: --clean --if-exists --no-owner --no-privileges --schema=public -v
```

Also made a slight refactor to echo statements to keep them consistent and colocate with related process execution.

## TODO

- [x] rebuild and push tags