### PR TITLE
feat: customize fluentd docker image for our use

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,0 +1,3 @@
+FROM fluent/fluentd-kubernetes-daemonset:v1.18-debian-papertrail-1
+
+RUN fluent-gem install fluent-plugin-s3

--- a/fluentd/build.sh
+++ b/fluentd/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Use: ./build.sh
+
+set -e
+
+docker build -t artsy/artsy-fluentd .
+
+docker login
+
+docker push artsy/artsy-fluentd:latest


### PR DESCRIPTION
The [off-the-shelf FluentD image](https://github.com/artsy/substance/pull/410/files#diff-f93fd760ceb77a8c8a08c349dc4959c70857163eca34377686d138bdf7c0469bL78) does not include S3 plugin which is now required to support https://github.com/artsy/substance/pull/410.

So let's bake our own image to include S3 plugin.

I have already run `build.sh` which pushed new image to [Dockerhub](https://hub.docker.com/repository/docker/artsy/artsy-fluentd/general).