### PR TITLE
feat: add ruby/3.3.0-node-22-yarn

### DIFF
--- a/ruby/3.3.0-node-22-yarn/Dockerfile
+++ b/ruby/3.3.0-node-22-yarn/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:3.4.1-alpine3.21
+
+# Install Node + Yarn
+ENV NODE_VERSION=22.5.1
+ENV YARN_VERSION=1.22.5
+
+RUN addgroup -g 1000 node \
+  && adduser -u 1000 -G node -s /bin/sh -D node \
+  && apk add --no-cache libstdc++ \
+  && apk add --no-cache --virtual .build-deps curl \
+  && curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  && rm -f "node-v$NODE_VERSION-linux-x64-musl.tar.xz" \
+  && apk del .build-deps
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --import \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn
+
+RUN node --version
+RUN yarn --version


### PR DESCRIPTION
We need to update `volt` to use `node` version `22`. `volt` relies on our custom `ruby`-`node` images. This adds a new dockerfile that will be used to build and push up a new image that can then be used in `volt`'s [dockerfile](https://github.com/artsy/volt/blob/main/Dockerfile#L1).  


### Migration 

- Build the image locally and follow the [push steps](https://github.com/artsy/docker-images?tab=readme-ov-file#adding-an-image-to-docker-hub).