### PR TITLE
fix: use correct ruby version for node 22

### DIFF
--- a/ruby/3.3.0-node-22-yarn/Dockerfile
+++ b/ruby/3.3.0-node-22-yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4.1-alpine3.21
+FROM ruby:3.3.0-alpine3.18
 
 # Install Node + Yarn
 ENV NODE_VERSION=22.5.1


### PR DESCRIPTION
Patches #119 to use the correct ruby version.

image already built and pushed.