### PR TITLE
feat: add opensearch v1.3.20 with repository-s3 plugin

### DIFF
--- a/opensearch/1.3.20/Dockerfile
+++ b/opensearch/1.3.20/Dockerfile
@@ -1,0 +1,3 @@
+FROM opensearchproject/opensearch:1.3.20
+
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch repository-s3


### PR DESCRIPTION
The PR creates a new Docker image for OpenSearch v1.3.20 with repository-s3 plugin. 

Ref: https://github.com/artsy/gravity/pull/19180#issuecomment-3197645123