### PR TITLE
Revert "feat: add opensearch v1.3.20 with repository-s3 plugin"

### DIFF
--- a/opensearch/1.3.20/Dockerfile
+++ b/opensearch/1.3.20/Dockerfile
@@ -1,3 +1,0 @@
-FROM opensearchproject/opensearch:1.3.20
-
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch repository-s3


### PR DESCRIPTION
Reverts artsy/docker-images#123 as we don't need the custom docker image for OpenSearch v1.3.20 with the plugin. 